### PR TITLE
add client connect helper and a mock server

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -26,7 +26,7 @@ const (
 )
 
 type AgentClient struct {
-	agentgrpc.HyperstartServiceClient
+	agentgrpc.AgentServiceClient
 	conn *grpc.ClientConn
 }
 
@@ -49,8 +49,8 @@ func NewAgentClient(sock string) (*AgentClient, error) {
 	}
 
 	return &AgentClient{
-		HyperstartServiceClient: agentgrpc.NewHyperstartServiceClient(conn),
-		conn: conn,
+		AgentServiceClient: agentgrpc.NewAgentServiceClient(conn),
+		conn:               conn,
 	}, nil
 }
 

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -25,6 +25,7 @@ const (
 	dialTimeout       = 5 * time.Second
 )
 
+// AgentClient is an agent gRPC client connection wrapper for agentgrpc.AgentServiceClient
 type AgentClient struct {
 	agentgrpc.AgentServiceClient
 	conn *grpc.ClientConn
@@ -32,6 +33,8 @@ type AgentClient struct {
 
 type dialer func(string, time.Duration) (net.Conn, error)
 
+// NewAgentClient creates a new agent gRPC client and handles both unix and vsock addresses.
+//
 // Supported sock address formats are:
 //   - unix://<unix socket path>
 //   - vsock://<cid>:<port>
@@ -54,6 +57,7 @@ func NewAgentClient(sock string) (*AgentClient, error) {
 	}, nil
 }
 
+// Close an existing connection to the agent gRPC server.
 func (c *AgentClient) Close() error {
 	return c.conn.Close()
 }

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -1,0 +1,94 @@
+// Copyright 2017 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// gRPC client wrapper
+
+package client
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mdlayher/vsock"
+	"google.golang.org/grpc"
+
+	agentgrpc "github.com/kata-project/agent/protocols/grpc"
+)
+
+const (
+	UNIX_SOCKET_PREFIX  = "unix://"
+	VSOCK_SOCKET_PREFIX = "vsock://"
+)
+
+type AgentClient struct {
+	agentgrpc.HyperstartServiceClient
+	conn *grpc.ClientConn
+}
+
+type dialer func(string, time.Duration) (net.Conn, error)
+
+// Supported sock address formats are:
+//   - unix://<unix socket path>
+//   - vsock://<cid>:<port>
+//   - <unix socket path>
+func NewAgentClient(sock string) (*AgentClient, error) {
+	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithTimeout(5 * time.Second)}
+	dialOpts = append(dialOpts, grpc.WithDialer(agentDialer(sock)))
+	conn, err := grpc.Dial(sock, dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AgentClient{
+		HyperstartServiceClient: agentgrpc.NewHyperstartServiceClient(conn),
+		conn: conn,
+	}, nil
+}
+
+func (c *AgentClient) Close() error {
+	return c.conn.Close()
+}
+
+func agentDialer(addr string) dialer {
+	switch {
+	case strings.HasPrefix(addr, VSOCK_SOCKET_PREFIX):
+		return vsockDialer
+	case strings.HasPrefix(addr, UNIX_SOCKET_PREFIX):
+		fallthrough
+	default:
+		return unixDialer
+	}
+}
+
+func unixDialer(addr string, timeout time.Duration) (net.Conn, error) {
+	if strings.HasPrefix(addr, UNIX_SOCKET_PREFIX) {
+		addr = addr[len(UNIX_SOCKET_PREFIX):]
+	}
+	return net.DialTimeout("unix", addr, timeout)
+}
+
+func vsockDialer(addr string, timeout time.Duration) (net.Conn, error) {
+	if strings.HasPrefix(addr, VSOCK_SOCKET_PREFIX) {
+		addr = addr[len(VSOCK_SOCKET_PREFIX):]
+	}
+
+	invalidVsockMsgErr := fmt.Errorf("invalid vsock destination: %s", VSOCK_SOCKET_PREFIX+addr)
+	seq := strings.Split(addr, ":")
+	if len(seq) != 2 {
+		return nil, invalidVsockMsgErr
+	}
+	cid, err := strconv.ParseUint(seq[0], 10, 32)
+	if err != nil {
+		return nil, invalidVsockMsgErr
+	}
+	port, err := strconv.ParseUint(seq[1], 10, 32)
+	if err != nil {
+		return nil, invalidVsockMsgErr
+	}
+
+	return vsock.Dial(uint32(cid), uint32(port))
+}

--- a/protocols/client/client_test.go
+++ b/protocols/client/client_test.go
@@ -1,0 +1,69 @@
+// Copyright 2017 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// gRPC client wrapper UT
+
+package client
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"github.com/kata-project/agent/protocols/mockserver"
+)
+
+const mockSockAddr = "/tmp/agentserver.sock"
+const unixMockAddr = "unix://" + mockSockAddr
+const badMockAddr = "vsock://" + mockSockAddr
+
+func startMockServer(t *testing.T) (*grpc.Server, chan error, error) {
+	os.Remove(mockSockAddr)
+
+	l, err := net.Listen("unix", mockSockAddr)
+	if err != nil {
+		t.Fatalf("Listen on %s failed: %s", mockSockAddr, err)
+	}
+
+	mock := mockserver.NewMockServer()
+
+	stopWait := make(chan error, 1)
+	go func() {
+		stopWait <- mock.Serve(l)
+	}()
+
+	return mock, stopWait, nil
+}
+
+func TestNewAgentClient(t *testing.T) {
+	mock, waitCh, err := startMockServer(t)
+	if err != nil {
+		t.Fatalf("failed to start mock server: %s", err)
+	}
+
+	cliFunc := func(sock string, success bool) {
+		cli, err := NewAgentClient(sock)
+		if success && err != nil {
+			t.Fatalf("Failed to create new agent client: %s", err)
+		} else if !success && err == nil {
+			t.Fatalf("Unexpected success with sock address: %s", sock)
+		}
+		if err == nil {
+			cli.Close()
+		}
+	}
+
+	cliFunc(mockSockAddr, true)
+	cliFunc(unixMockAddr, true)
+	cliFunc(badMockAddr, false)
+
+	// wait mock server to stop
+	mock.Stop()
+	err = <-waitCh
+	if err != nil {
+		t.Fatalf("mock server failed: %s", err)
+	}
+}

--- a/protocols/client/client_test.go
+++ b/protocols/client/client_test.go
@@ -32,7 +32,8 @@ func startMockServer(t *testing.T) (*grpc.Server, chan error, error) {
 
 	stopWait := make(chan error, 1)
 	go func() {
-		stopWait <- mock.Serve(l)
+		mock.Serve(l)
+		stopWait <- nil
 	}()
 
 	return mock, stopWait, nil

--- a/protocols/mockserver/mockserver.go
+++ b/protocols/mockserver/mockserver.go
@@ -1,0 +1,268 @@
+// Copyright 2017 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// gRPC mock server
+
+package mockserver
+
+import (
+	"errors"
+
+	google_protobuf "github.com/golang/protobuf/ptypes/empty"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	pb "github.com/kata-project/agent/protocols/grpc"
+)
+
+type pod struct {
+	containers map[string]*container
+}
+
+type container struct {
+	id   string
+	init string // init process name
+	proc map[string]*process
+}
+
+type process struct {
+	id   string
+	proc *pb.Process
+}
+
+type mockServer struct {
+	pod *pod
+}
+
+func NewMockServer() *grpc.Server {
+	mock := &mockServer{}
+	serv := grpc.NewServer()
+	pb.RegisterHyperstartServiceServer(serv, mock)
+
+	return serv
+}
+
+func validateOCISpec(spec *pb.Spec) error {
+	if spec == nil || spec.Process == nil {
+		return errors.New("invalid container spec")
+	}
+	return nil
+}
+
+func (m *mockServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	if m.pod.containers[req.ContainerId] != nil {
+		return nil, errors.New("container ID already taken")
+	}
+	if err := validateOCISpec(req.OCI); err != nil {
+		return nil, err
+	}
+
+	c := &container{
+		id:   req.ContainerId,
+		proc: make(map[string]*process),
+	}
+	c.init = "init"
+	p := &process{
+		id:   c.init,
+		proc: req.OCI.Process,
+	}
+	c.proc[c.init] = p
+	m.pod.containers[req.ContainerId] = c
+
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	if m.pod.containers[req.ContainerId] == nil {
+		return nil, errors.New("container does not exist")
+	}
+
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] != nil {
+		return nil, errors.New("process name taken")
+	}
+	c.proc[req.ProcessId] = &process{
+		id:   req.ProcessId,
+		proc: req.Process,
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] == nil {
+		return nil, errors.New("process does not exist")
+	}
+
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] == nil {
+		return nil, errors.New("process does not exist")
+	}
+
+	// remove process once it is waited
+	c.proc[req.ProcessId] = nil
+
+	return &pb.WaitProcessResponse{Status: 0}, nil
+}
+
+func (m *mockServer) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] == nil {
+		return nil, errors.New("process does not exist")
+	}
+
+	return &pb.WriteStreamResponse{Len: uint32(len(req.Data))}, nil
+}
+
+func (m *mockServer) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] == nil {
+		return nil, errors.New("process does not exist")
+	}
+
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (m *mockServer) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+
+	c := m.pod.containers[req.ContainerId]
+	if c == nil {
+		return nil, errors.New("container does not exist")
+	}
+	if c.proc[req.ProcessId] == nil {
+		return nil, errors.New("process does not exist")
+	}
+
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (m *mockServer) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	if req.ContainerId == "" {
+		return nil, errors.New("container ID must be set")
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*google_protobuf.Empty, error) {
+	if m.pod != nil {
+		return nil, errors.New("pod already created")
+	}
+	m.pod = &pod{
+		containers: make(map[string]*container),
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*google_protobuf.Empty, error) {
+	m.pod = nil
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) AddRoute(ctx context.Context, req *pb.AddRouteRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	return &google_protobuf.Empty{}, nil
+}
+
+func (m *mockServer) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*google_protobuf.Empty, error) {
+	if m.pod == nil {
+		return nil, errors.New("pod not created")
+	}
+	return &google_protobuf.Empty{}, nil
+}

--- a/protocols/mockserver/mockserver.go
+++ b/protocols/mockserver/mockserver.go
@@ -10,25 +10,29 @@ import (
 	"errors"
 	"fmt"
 
-	google_protobuf "github.com/golang/protobuf/ptypes/empty"
+	google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	pb "github.com/kata-project/agent/protocols/grpc"
 )
 
+const podStartingPid = 100
+
 type pod struct {
+	nextPid    uint32
 	containers map[string]*container
 }
 
+// container init process pid is always
 type container struct {
-	id   string
-	init string // init process name
-	proc map[string]*process
+	id      string
+	initPid uint32
+	proc    map[uint32]*process
 }
 
 type process struct {
-	id   string
+	pid  uint32
 	proc *pb.Process
 }
 
@@ -39,7 +43,7 @@ type mockServer struct {
 func NewMockServer() *grpc.Server {
 	mock := &mockServer{}
 	serv := grpc.NewServer()
-	pb.RegisterHyperstartServiceServer(serv, mock)
+	pb.RegisterAgentServiceServer(serv, mock)
 
 	return serv
 }
@@ -51,14 +55,20 @@ func validateOCISpec(spec *pb.Spec) error {
 	return nil
 }
 
-func (m *mockServer) checkExist(containerId, processId string, createContainer, checkProcess, createProcess bool) error {
+func (m *mockServer) nextPid() uint32 {
+	pid := m.pod.nextPid
+	m.pod.nextPid += 1
+	return pid
+}
+
+func (m *mockServer) checkExist(containerId string, pid uint32, createContainer, checkProcess bool) error {
 	if m.pod == nil {
 		return errors.New("pod not created")
 	}
 	if containerId == "" {
 		return errors.New("container ID must be set")
 	}
-	if checkProcess && processId == "" {
+	if checkProcess && pid == 0 {
 		return errors.New("process ID must be set")
 	}
 
@@ -73,33 +83,26 @@ func (m *mockServer) checkExist(containerId, processId string, createContainer, 
 	}
 
 	// Check process existence
-	if processId != "" {
+	if checkProcess {
 		c := m.pod.containers[containerId]
-		if createProcess && c.proc[processId] != nil {
-			return fmt.Errorf("process ID %s already taken", processId)
-		}
-		if !createProcess && c.proc[processId] == nil {
-			return fmt.Errorf("process %s does not exist", processId)
+		if c.proc[pid] == nil {
+			return fmt.Errorf("process %d does not exist", pid)
 		}
 	}
 
 	return nil
 }
 
-func (m *mockServer) processExist(containerId, processId string) error {
-	return m.checkExist(containerId, processId, false, true, false)
-}
-
-func (m *mockServer) processNonExist(containerId, processId string) error {
-	return m.checkExist(containerId, processId, false, true, true)
+func (m *mockServer) processExist(containerId string, pid uint32) error {
+	return m.checkExist(containerId, pid, false, true)
 }
 
 func (m *mockServer) containerExist(containerId string) error {
-	return m.checkExist(containerId, "", false, false, false)
+	return m.checkExist(containerId, 0, false, false)
 }
 
 func (m *mockServer) containerNonExist(containerId string) error {
-	return m.checkExist(containerId, "", true, false, false)
+	return m.checkExist(containerId, 0, true, false)
 }
 
 func (m *mockServer) podExist() error {
@@ -109,7 +112,7 @@ func (m *mockServer) podExist() error {
 	return nil
 }
 
-func (m *mockServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*google_protobuf2.Empty, error) {
 	if err := m.containerNonExist(req.ContainerId); err != nil {
 		return nil, err
 	}
@@ -120,62 +123,74 @@ func (m *mockServer) CreateContainer(ctx context.Context, req *pb.CreateContaine
 
 	c := &container{
 		id:   req.ContainerId,
-		proc: make(map[string]*process),
+		proc: make(map[uint32]*process),
 	}
-	c.init = "init"
-	p := &process{
-		id:   c.init,
+	c.initPid = m.nextPid()
+	c.proc[c.initPid] = &process{
+		pid:  c.initPid,
 		proc: req.OCI.Process,
 	}
-	c.proc[c.init] = p
 	m.pod.containers[req.ContainerId] = c
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*pb.NewProcessResponse, error) {
 	if err := m.containerNonExist(req.ContainerId); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &pb.NewProcessResponse{PID: m.pod.containers[req.ContainerId].initPid}, nil
 }
 
-func (m *mockServer) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*google_protobuf.Empty, error) {
-	if err := m.processNonExist(req.ContainerId, req.ProcessId); err != nil {
+func (m *mockServer) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*google_protobuf2.Empty, error) {
+	if err := m.containerExist(req.ContainerId); err != nil {
+		return nil, err
+	}
+
+	return &google_protobuf2.Empty{}, nil
+}
+
+func (m *mockServer) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*pb.NewProcessResponse, error) {
+	if err := m.containerExist(req.ContainerId); err != nil {
 		return nil, err
 	}
 
 	c := m.pod.containers[req.ContainerId]
-	c.proc[req.ProcessId] = &process{
-		id:   req.ProcessId,
+	pid := m.nextPid()
+	c.proc[pid] = &process{
+		pid:  pid,
 		proc: req.Process,
 	}
-	return &google_protobuf.Empty{}, nil
+	return &pb.NewProcessResponse{PID: pid}, nil
 }
 
-func (m *mockServer) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*google_protobuf.Empty, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+func (m *mockServer) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*google_protobuf2.Empty, error) {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
 func (m *mockServer) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
 	// remove process once it is waited
 	c := m.pod.containers[req.ContainerId]
-	c.proc[req.ProcessId] = nil
+	c.proc[req.PID] = nil
+	// container gone, clean it up
+	if c.initPid == req.PID {
+		m.pod.containers[req.ContainerId] = nil
+	}
 
 	return &pb.WaitProcessResponse{Status: 0}, nil
 }
 
 func (m *mockServer) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
@@ -183,7 +198,7 @@ func (m *mockServer) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest)
 }
 
 func (m *mockServer) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
@@ -191,68 +206,93 @@ func (m *mockServer) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) 
 }
 
 func (m *mockServer) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
 	return &pb.ReadStreamResponse{}, nil
 }
 
-func (m *mockServer) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*google_protobuf.Empty, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+func (m *mockServer) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*google_protobuf2.Empty, error) {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*google_protobuf.Empty, error) {
-	if err := m.processExist(req.ContainerId, req.ProcessId); err != nil {
+func (m *mockServer) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*google_protobuf2.Empty, error) {
+	if err := m.processExist(req.ContainerId, req.PID); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*google_protobuf2.Empty, error) {
 	if m.pod != nil {
 		return nil, errors.New("pod already created")
 	}
 	m.pod = &pod{
+		nextPid:    podStartingPid,
 		containers: make(map[string]*container),
 	}
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*google_protobuf2.Empty, error) {
 	if err := m.podExist(); err != nil {
 		return nil, err
 	}
 
 	m.pod = nil
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) AddInterface(context.Context, *pb.AddInterfaceRequest) (*google_protobuf2.Empty, error) {
 	if err := m.podExist(); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) AddRoute(ctx context.Context, req *pb.AddRouteRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) RemoveInterface(context.Context, *pb.RemoveInterfaceRequest) (*google_protobuf2.Empty, error) {
 	if err := m.podExist(); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
 }
 
-func (m *mockServer) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*google_protobuf.Empty, error) {
+func (m *mockServer) RemoveRoute(context.Context, *pb.RouteRequest) (*google_protobuf2.Empty, error) {
 	if err := m.podExist(); err != nil {
 		return nil, err
 	}
 
-	return &google_protobuf.Empty{}, nil
+	return &google_protobuf2.Empty{}, nil
+}
+
+func (m *mockServer) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*google_protobuf2.Empty, error) {
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return &google_protobuf2.Empty{}, nil
+}
+
+func (m *mockServer) AddRoute(ctx context.Context, req *pb.RouteRequest) (*google_protobuf2.Empty, error) {
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return &google_protobuf2.Empty{}, nil
+}
+
+func (m *mockServer) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*google_protobuf2.Empty, error) {
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return &google_protobuf2.Empty{}, nil
 }


### PR DESCRIPTION
The client connect helper can be reused by both the shim and the runtime. The mock server can be used to test client side code without having to wait for the agent to be ready.

Please do not merge it yet. I want to rebase it after #9 is merged so that we get basic container and process tracking in the mock server.