### PR TITLE
agent: Implement subreaper support

### DIFF
--- a/api.go
+++ b/api.go
@@ -23,6 +23,14 @@ const (
 	vSockPort    = 1024
 )
 
+// Signals
+const (
+	// If a process terminates because of signal "n"
+	// The exit code is "128 + signal_number"
+	// http://tldp.org/LDP/abs/html/exitcodes.html
+	exitSignalOffset = 128
+)
+
 // Global
 const (
 	agentName       = "kata-agent"

--- a/grpc.go
+++ b/grpc.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"syscall"
@@ -35,14 +34,6 @@ type agentGRPC struct {
 const (
 	pciBusRescanFile = "/sys/bus/pci/rescan"
 	pciBusMode       = 0220
-)
-
-// Signals
-const (
-	// If a process terminates because of signal "n"
-	// The exit code is "128 + signal_number"
-	// http://tldp.org/LDP/abs/html/exitcodes.html
-	exitSignalOffset = 128
 )
 
 // CPU and Memory hotplug
@@ -169,7 +160,7 @@ func buildProcess(agentProcess *pb.Process) (*process, error) {
 	user := agentProcess.User.Username
 	if user == "" {
 		// We can specify the user and the group separated by ":"
-		user = fmt.Sprintf("%s:%s", agentProcess.User.UID, agentProcess.User.GID)
+		user = fmt.Sprintf("%d:%d", agentProcess.User.UID, agentProcess.User.GID)
 	}
 
 	additionalGids := []string{}
@@ -231,7 +222,7 @@ func (a *agentGRPC) Check(ctx context.Context, req *pb.CheckRequest) (*pb.Health
 
 func (a *agentGRPC) Version(ctx context.Context, req *pb.CheckRequest) (*pb.VersionCheckResponse, error) {
 	return &pb.VersionCheckResponse{
-		GrpcVersion: pb.APIVersion,
+		GrpcVersion:  pb.APIVersion,
 		AgentVersion: a.version,
 	}, nil
 
@@ -273,6 +264,15 @@ func (a *agentGRPC) runProcess(cid string, agentProcess *pb.Process) (pid int, e
 		proc = ctr.initProcess
 	}
 
+	// This lock is very important to avoid any race with reaper.reap().
+	// Indeed, if we don't lock this here, we could potentially get the
+	// SIGCHLD signal before the channel has been created, meaning we will
+	// miss the opportunity to get the exit code, leading WaitProcess() to
+	// wait forever on the new channel.
+	// This lock has to be taken before we run the new process.
+	a.sandbox.subreaper.RLock()
+	defer a.sandbox.subreaper.RUnlock()
+
 	if err := ctr.container.Run(&(proc.process)); err != nil {
 		return -1, fmt.Errorf("Could not run process: %v", err)
 	}
@@ -283,6 +283,11 @@ func (a *agentGRPC) runProcess(cid string, agentProcess *pb.Process) (pid int, e
 	if err != nil {
 		return -1, err
 	}
+
+	// Create process channel to allow WaitProcess to wait on it.
+	// This channel is buffered so that reaper.reap() will not
+	// block until WaitProcess listen onto this channel.
+	a.sandbox.subreaper.setExitCodeCh(pid, make(chan int, 1))
 
 	// Setup terminal if enabled.
 	if proc.consoleSock != nil {
@@ -520,34 +525,11 @@ func (a *agentGRPC) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest)
 		ctr.deleteProcess(proc.id)
 	}()
 
-	fieldLogger := agentLog.WithField("container-pid", proc.id)
-
-	processState, err := proc.process.Wait()
-	// Ignore error if process fails because of an unsuccessful exit code
-	if _, ok := err.(*exec.ExitError); err != nil && !ok {
-		fieldLogger.WithError(err).Error("Process wait failed")
-	}
-
-	// Get exit code
-	exitCode := 255
-	if processState != nil {
-		fieldLogger = fieldLogger.WithField("process-state", fmt.Sprintf("%+v", processState))
-		fieldLogger.Info("Got process state")
-
-		if waitStatus, ok := processState.Sys().(syscall.WaitStatus); ok {
-			exitStatus := waitStatus.ExitStatus()
-
-			if waitStatus.Signaled() {
-				exitCode = exitSignalOffset + int(waitStatus.Signal())
-				fieldLogger.WithField("exit-code", exitCode).Info("process was signaled")
-			} else {
-				exitCode = exitStatus
-				fieldLogger.WithField("exit-code", exitCode).Info("got wait exit code")
-			}
-		}
-
-	} else {
-		fieldLogger.Error("Process state is nil could not get process exit code")
+	// Using helper function wait() to deal with the subreaper.
+	libContProcess := (*reaperLibcontainerProcess)(&(proc.process))
+	exitCode, err := a.sandbox.subreaper.wait(proc.id, libContProcess)
+	if err != nil {
+		return &pb.WaitProcessResponse{}, err
 	}
 
 	return &pb.WaitProcessResponse{
@@ -689,6 +671,7 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 	}
 
 	a.sandbox.id = req.Hostname
+	a.sandbox.containers = make(map[string]*container)
 	a.sandbox.network.dns = req.Dns
 	a.sandbox.running = true
 

--- a/reaper.go
+++ b/reaper.go
@@ -1,0 +1,185 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type reaper struct {
+	sync.RWMutex
+
+	chansLock     sync.RWMutex
+	exitCodeChans map[int]chan int
+}
+
+func exitStatus(status unix.WaitStatus) int {
+	if status.Signaled() {
+		return exitSignalOffset + int(status.Signal())
+	}
+
+	return status.ExitStatus()
+}
+
+func (r *reaper) getExitCodeCh(pid int) (chan int, error) {
+	r.chansLock.RLock()
+	defer r.chansLock.RUnlock()
+
+	exitCodeCh, exist := r.exitCodeChans[pid]
+	if !exist {
+		return nil, fmt.Errorf("Process %d not found", pid)
+	}
+
+	return exitCodeCh, nil
+}
+
+func (r *reaper) setExitCodeCh(pid int, exitCodeCh chan int) {
+	r.chansLock.Lock()
+	defer r.chansLock.Unlock()
+
+	r.exitCodeChans[pid] = exitCodeCh
+}
+
+func (r *reaper) deleteExitCodeCh(pid int) {
+	r.chansLock.Lock()
+	defer r.chansLock.Unlock()
+
+	exitCodeCh, exist := r.exitCodeChans[pid]
+	if !exist {
+		return
+	}
+
+	close(exitCodeCh)
+
+	delete(r.exitCodeChans, pid)
+}
+
+func (r *reaper) reap() error {
+	var (
+		ws  unix.WaitStatus
+		rus unix.Rusage
+	)
+
+	// When running new processes, libcontainer expects to wait
+	// for the first process actually spawning the container.
+	// This lock allows any code starting a new process to take
+	// the lock prior to the start of this new process, preventing
+	// the subreaper from reaping unwanted processes.
+	r.Lock()
+	defer r.Unlock()
+
+	for {
+		pid, err := unix.Wait4(-1, &ws, unix.WNOHANG, &rus)
+		if err != nil {
+			if err == unix.ECHILD {
+				return nil
+			}
+
+			return err
+		}
+		if pid < 1 {
+			return nil
+		}
+
+		status := exitStatus(ws)
+
+		agentLog.WithFields(logrus.Fields{
+			"pid":    pid,
+			"status": status,
+		}).Debug("process exited")
+
+		exitCodeCh, err := r.getExitCodeCh(pid)
+		if err != nil {
+			// No need to signal a process with no channel
+			// associated. When a process has not been registered,
+			// this means the spawner does not expect to get the
+			// exit code from this process.
+			continue
+		}
+
+		// Here, we have to signal the routine listening on
+		// this channel so that it can complete the cleanup
+		// of the process and return the exit code to the
+		// caller of WaitProcess().
+		exitCodeCh <- status
+	}
+}
+
+// start starts the exec command and registers the process to the reaper.
+// This function is a helper for exec.Cmd.Start() since this needs to be
+// in sync with exec.Cmd.Wait().
+func (r *reaper) start(c *exec.Cmd) error {
+	// This lock is very important to avoid any race with reaper.reap().
+	// We don't want the reaper to reap a process before we have added
+	// it to the exit code channel list.
+	r.RLock()
+	defer r.RUnlock()
+
+	if err := c.Start(); err != nil {
+		return err
+	}
+
+	// This channel is buffered so that reaper.reap() will not
+	// block until reaper.wait() listen onto this channel.
+	r.setExitCodeCh(c.Process.Pid, make(chan int, 1))
+
+	return nil
+}
+
+// wait blocks until the expected process has been reaped. After the reaping
+// from the subreaper, the exit code is sent through the provided channel.
+// This function is a helper for exec.Cmd.Wait() and os.Process.Wait() since
+// both cannot be used directly, because of the subreaper.
+func (r *reaper) wait(pid int, proc waitProcess) (int, error) {
+	exitCodeCh, err := r.getExitCodeCh(pid)
+	if err != nil {
+		return -1, err
+	}
+
+	// Wait for the subreaper to receive the SIGCHLD signal. Once it gets
+	// it, this channel will be notified by receiving the exit code of the
+	// corresponding process.
+	exitCode := <-exitCodeCh
+
+	// Ignore errors since the process has already been reaped by the
+	// subreaping loop. This call is only used to make sure libcontainer
+	// properly cleans up its internal structures and pipes.
+	proc.wait()
+
+	r.deleteExitCodeCh(pid)
+
+	return exitCode, nil
+}
+
+type waitProcess interface {
+	wait()
+}
+
+type reaperOSProcess os.Process
+
+func (p *reaperOSProcess) wait() {
+	(*os.Process)(p).Wait()
+}
+
+type reaperExecCmd exec.Cmd
+
+func (c *reaperExecCmd) wait() {
+	(*exec.Cmd)(c).Wait()
+}
+
+type reaperLibcontainerProcess libcontainer.Process
+
+func (p *reaperLibcontainerProcess) wait() {
+	(*libcontainer.Process)(p).Wait()
+}


### PR DESCRIPTION
agent: Implement subreaper support
    
This commit turns the agent into a subreaper, in order to reap all
    the processes started from any container. This is the only way to
    make sure we won't end up with some zombies processes in case we
    have some child processes terminating before their own children.
    
Fixes #23
    
Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>