### PR TITLE
agent: Add shared PID namespace support

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,4 +30,5 @@ const (
 	exitFailure     = 1
 	fileMode0750    = 0750
 	defaultLogLevel = logrus.InfoLevel
+	selfBinPath     = "/proc/self/exe"
 )

--- a/pause.go
+++ b/pause.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+/*
+#cgo CFLAGS: -Wall
+#define _GNU_SOURCE
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define PAUSE_BIN "pause-bin"
+
+static void sigdown(int signo) {
+	psignal(signo, "shutting down, got signal");
+	exit(0);
+}
+
+void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
+	if (argc != 2 || strcmp(argv[1], PAUSE_BIN)) {
+		return;
+	}
+
+	if (signal(SIGINT, sigdown) == SIG_ERR)
+		exit(1);
+
+	if (signal(SIGTERM, sigdown) == SIG_ERR)
+		exit(2);
+
+	for (;;) pause();
+
+	fprintf(stderr, "error: infinite loop terminated\n");
+	exit(42);
+}
+*/
+import "C"
+
+const (
+	pauseBinArg = string(C.PAUSE_BIN)
+)


### PR DESCRIPTION
    agent: Add shared PID namespace support
    
    We want to be able to share the same PID namespace across all
    containers of a sandbox. This commit allows for such a thing by
    starting a new process from a pause binary, into a new PID ns.
    
    This way, the process is considered as init process inside this
    namespace and the namespace will exist as long as this process
    runs.
    
    Fixes #20
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>