### PR TITLE
build: Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+agent:
+	go build -o $@
+
+.PHONY: clean
+clean:
+	rm -f agent


### PR DESCRIPTION
    build: Add a Makefile
    
    This commit adds a makefile in order to simplify the build commands.
    
    Fixes #30
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>