### PR TITLE
build: Name the binary "kata-agent"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-agent
+kata-agent

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-agent:
+TARGET = kata-agent
+
+$(TARGET):
 	go build -o $@
 
 .PHONY: clean
 clean:
-	rm -f agent
+	rm -f $(TARGET)


### PR DESCRIPTION
Create the binary as "kata-agent" as "agent" is too generic.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>