### PR TITLE
logging: Use structured logging and simplest log calls

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -287,7 +287,7 @@ func init() {
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			agentLog.Errorf("init went wrong: %v", err)
+			agentLog.WithError(err).Error("init failed")
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}

--- a/network.go
+++ b/network.go
@@ -229,7 +229,7 @@ func (s *sandbox) updateInterface(netHandle *netlink.Handle, iface *pb.Interface
 		return fmt.Errorf("Interface HwAddr and Name are both empty")
 	}
 
-	fieldLogger.WithField("link", fmt.Sprintf("%+v", link)).Infof("Link found")
+	fieldLogger.WithField("link", fmt.Sprintf("%+v", link)).Info("Link found")
 
 	lAttrs := link.Attrs()
 	if lAttrs != nil && (lAttrs.Flags&net.FlagUp) == net.FlagUp {


### PR DESCRIPTION
Use more structured logging and don't use the printf-style log calls
unless actually needed.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>