### PR TITLE
build: Add version details to binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,14 @@ GENERATED_FILES := $(UNIT_FILES)
 UNIT_FILES += kata-containers.target
 endif
 
-$(TARGET): $(GENERATED_FILES)
-	go build -o $@
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+
+$(TARGET): $(GENERATED_FILES) $(VERSION_FILE)
+	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 install:
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TARGET = kata-agent
+SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
 DESTDIR :=
 PREFIX := /usr
@@ -24,7 +25,7 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-$(TARGET): $(GENERATED_FILES) $(VERSION_FILE)
+$(TARGET): $(GENERATED_FILES) $(SOURCES) $(VERSION_FILE)
 	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 install:

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+# This is the agent version.
+0.0.1

--- a/agent.go
+++ b/agent.go
@@ -61,8 +61,8 @@ var agentLog = logrus.WithFields(logrus.Fields{
 	"pid":  os.Getpid(),
 })
 
-// Version is the agent version. This variable is populated at build time.
-var Version = "unknown"
+// version is the agent version. This variable is populated at build time.
+var version = "unknown"
 
 // This is the list of file descriptors we can properly close after the process
 // has been started. When the new process is exec(), those file descriptors are
@@ -232,7 +232,7 @@ func (s *sandbox) initLogger() error {
 	}
 	config.applyConfig()
 
-	agentLog.WithField("version", Version).Info()
+	agentLog.WithField("version", version).Info()
 
 	return nil
 }


### PR DESCRIPTION
Generate a version string containing version number and commit that the
agent logs in when initialising the logger.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>