### PR TITLE
pause-bin: remove signal handlers

### DIFF
--- a/pause.go
+++ b/pause.go
@@ -17,21 +17,10 @@ package main
 
 #define PAUSE_BIN "pause-bin"
 
-static void sigdown(int signo) {
-	psignal(signo, "shutting down, got signal");
-	exit(0);
-}
-
 void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
 	if (argc != 2 || strcmp(argv[1], PAUSE_BIN)) {
 		return;
 	}
-
-	if (signal(SIGINT, sigdown) == SIG_ERR)
-		exit(1);
-
-	if (signal(SIGTERM, sigdown) == SIG_ERR)
-		exit(2);
 
 	for (;;) pause();
 

--- a/pause_test.go
+++ b/pause_test.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2017 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForkPauseBin(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("skipping fork pause bin test that requires root")
+		return
+	}
+	cmd := &exec.Cmd{
+		Path: agentName,
+		Args: []string{os.Args[0], pauseBinArg},
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWPID,
+	}
+
+	err := cmd.Start()
+	assert.Nil(t, err, "Failed to fork pause binary: %s", err)
+
+	_, err = os.Stat(fmt.Sprintf("/proc/%d/ns/pid", cmd.Process.Pid))
+	assert.Nil(t, err, "Failed to stat pidns of pid %d: %s", cmd.Process.Pid, err)
+
+	err = cmd.Process.Kill()
+	assert.Nil(t, err, "Failed to kill pause binary: %s", err)
+
+	_, err = cmd.Process.Wait()
+	assert.Nil(t, err, "Failed to wait killed pause binary: %s", err)
+}


### PR DESCRIPTION
Remove signal handlers from pause-bin to prevent it from being
killed by other members of the pid namespace, causing all processes
in the same pid namespace being killed.

The agent can always kill the pause-bin with SIGKILL from outside.

Signed-off-by: Peng Tao <bergwolf@gmail.com>