### PR TITLE
pullapprove: A pull request needs 2 approval to be merged

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -27,6 +27,6 @@ group_defaults:
 
 groups:
   approvers:
-    required: 1
+    required: 2
     teams:
       - agent


### PR DESCRIPTION
We should expect more than one approval from one of our approvers list
in order to consider a pull request as mergeable.

Fixes #67

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>