### PR TITLE
change most fmt.Errorf to "google.golang.org/grpc/status"

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"github.com/hashicorp/yamux"
 	"github.com/mdlayher/vsock"
 	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 type channel interface {
@@ -159,7 +160,7 @@ func findVirtualSerialPath(serialName string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Could not find virtio port %s", serialName)
+	return "", grpcStatus.Errorf(codes.NotFound, "Could not find virtio port %s", serialName)
 }
 
 func openSerialChannel() (*os.File, error) {

--- a/config.go
+++ b/config.go
@@ -7,11 +7,12 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 const (
@@ -33,7 +34,7 @@ func newConfig(level logrus.Level) agentConfig {
 //Get the agent configuration from kernel cmdline
 func (c *agentConfig) getConfig(cmdLineFile string) error {
 	if cmdLineFile == "" {
-		return fmt.Errorf("Kernel cmdline file cannot be empty")
+		return grpcStatus.Error(codes.FailedPrecondition, "Kernel cmdline file cannot be empty")
 	}
 
 	kernelCmdline, err := ioutil.ReadFile(cmdLineFile)
@@ -82,7 +83,7 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 		c.logLevel = level
 	default:
 		if strings.HasPrefix(split[optionPosition], optionPrefix) {
-			return fmt.Errorf("Unknown option %s", split[optionPosition])
+			return grpcStatus.Errorf(codes.NotFound, "Unknown option %s", split[optionPosition])
 		}
 	}
 

--- a/pkg/uevent/uevent.go
+++ b/pkg/uevent/uevent.go
@@ -8,12 +8,13 @@ package uevent
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 const (
@@ -112,7 +113,7 @@ func (h *Handler) Read() (*Uevent, error) {
 
 		idx := strings.Index(keyValue, "=")
 		if idx < 1 {
-			return nil, fmt.Errorf("Could not decode uevent: Wrong format %q", keyValue)
+			return nil, grpcStatus.Errorf(codes.InvalidArgument, "Could not decode uevent: Wrong format %q", keyValue)
 		}
 
 		// The key is the first parameter, and the value is the rest

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -8,7 +8,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/url"
 	"strconv"
@@ -17,6 +16,8 @@ import (
 
 	"github.com/mdlayher/vsock"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 
 	agentgrpc "github.com/kata-containers/agent/protocols/grpc"
 )
@@ -89,20 +90,20 @@ func parse(sock string) (string, *url.URL, error) {
 	switch addr.Scheme {
 	case vsockSocketScheme:
 		if addr.Hostname() == "" || addr.Port() == "" || addr.Path != "" {
-			return "", nil, fmt.Errorf("Invalid vsock scheme: %s", sock)
+			return "", nil, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock scheme: %s", sock)
 		}
 		if _, err := strconv.ParseUint(addr.Hostname(), 10, 32); err != nil {
-			return "", nil, fmt.Errorf("Invalid vsock cid: %s", sock)
+			return "", nil, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock cid: %s", sock)
 		}
 		if _, err := strconv.ParseUint(addr.Port(), 10, 32); err != nil {
-			return "", nil, fmt.Errorf("Invalid vsock port: %s", sock)
+			return "", nil, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock port: %s", sock)
 		}
 		grpcAddr = vsockSocketScheme + ":" + addr.Host
 	case unixSocketScheme:
 		fallthrough
 	case "":
 		if (addr.Host == "" && addr.Path == "") || addr.Port() != "" {
-			return "", nil, fmt.Errorf("Invalid unix scheme: %s", sock)
+			return "", nil, grpcStatus.Errorf(codes.InvalidArgument, "Invalid unix scheme: %s", sock)
 		}
 		if addr.Host == "" {
 			grpcAddr = unixSocketScheme + ":///" + addr.Path
@@ -110,7 +111,7 @@ func parse(sock string) (string, *url.URL, error) {
 			grpcAddr = unixSocketScheme + ":///" + addr.Host + "/" + addr.Path
 		}
 	default:
-		return "", nil, fmt.Errorf("Invalid scheme: %s", sock)
+		return "", nil, grpcStatus.Errorf(codes.InvalidArgument, "Invalid scheme: %s", sock)
 	}
 
 	return grpcAddr, addr, nil
@@ -135,19 +136,19 @@ func unixDialer(sock string, timeout time.Duration) (net.Conn, error) {
 func parseGrpcVsockAddr(sock string) (uint32, uint32, error) {
 	sp := strings.Split(sock, ":")
 	if len(sp) != 3 {
-		return 0, 0, fmt.Errorf("Invalid vsock address: %s", sock)
+		return 0, 0, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock address: %s", sock)
 	}
 	if sp[0] != vsockSocketScheme {
-		return 0, 0, fmt.Errorf("Invalid vsock URL scheme: %s", sp[0])
+		return 0, 0, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock URL scheme: %s", sp[0])
 	}
 
 	cid, err := strconv.ParseUint(sp[1], 10, 32)
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid vsock cid: %s", sp[1])
+		return 0, 0, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock cid: %s", sp[1])
 	}
 	port, err := strconv.ParseUint(sp[2], 10, 32)
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid vsock port: %s", sp[2])
+		return 0, 0, grpcStatus.Errorf(codes.InvalidArgument, "Invalid vsock port: %s", sp[2])
 	}
 
 	return uint32(cid), uint32(port), nil
@@ -187,7 +188,7 @@ func vsockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 
 	var conn net.Conn
 	var ok bool
-	timeoutErrMsg := fmt.Errorf("timed out connecting to vsock %d:%d", cid, port)
+	timeoutErrMsg := grpcStatus.Errorf(codes.DeadlineExceeded, "timed out connecting to vsock %d:%d", cid, port)
 	select {
 	case conn, ok = <-ch:
 		if !ok {

--- a/protocols/grpc/utils.go
+++ b/protocols/grpc/utils.go
@@ -7,8 +7,10 @@
 package grpc
 
 import (
-	"fmt"
 	"reflect"
+
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -60,7 +62,7 @@ func copyValue(to, from reflect.Value) error {
 				return nil
 			}
 
-			return fmt.Errorf("Can not convert %v to %v", from.Type(), to.Type())
+			return grpcStatus.Errorf(codes.InvalidArgument, "Can not convert %v to %v", from.Type(), to.Type())
 		}
 
 		to.Set(from)
@@ -70,7 +72,7 @@ func copyValue(to, from reflect.Value) error {
 
 func copyMapValue(to, from reflect.Value) error {
 	if to.Kind() != reflect.Map && from.Kind() != reflect.Map {
-		return fmt.Errorf("Can only copy maps into maps")
+		return grpcStatus.Errorf(codes.InvalidArgument, "Can only copy maps into maps")
 	}
 
 	to.Set(reflect.MakeMap(to.Type()))
@@ -93,7 +95,7 @@ func copyMapValue(to, from reflect.Value) error {
 
 func copySliceValue(to, from reflect.Value) error {
 	if to.Kind() != reflect.Slice && from.Kind() != reflect.Slice {
-		return fmt.Errorf("Can only copy slices into slices")
+		return grpcStatus.Errorf(codes.InvalidArgument, "Can only copy slices into slices")
 	}
 
 	sliceLen := from.Len()
@@ -130,7 +132,7 @@ func copyStructSkipField(to, from reflect.Value) bool {
 
 func structFieldName(v reflect.Value, index int) (string, error) {
 	if v.Kind() != reflect.Struct {
-		return "", fmt.Errorf("Can only infer field name from structs")
+		return "", grpcStatus.Errorf(codes.InvalidArgument, "Can only infer field name from structs")
 	}
 
 	return v.Type().Field(index).Name, nil
@@ -146,7 +148,7 @@ func isEmbeddedStruct(v reflect.Value, index int) bool {
 
 func findStructField(v reflect.Value, name string) (reflect.Value, error) {
 	if v.Kind() != reflect.Struct {
-		return reflect.Value{}, fmt.Errorf("Can only infer field name from structs")
+		return reflect.Value{}, grpcStatus.Errorf(codes.InvalidArgument, "Can only infer field name from structs")
 	}
 
 	for i := 0; i < v.NumField(); i++ {
@@ -155,12 +157,12 @@ func findStructField(v reflect.Value, name string) (reflect.Value, error) {
 		}
 	}
 
-	return reflect.Value{}, fmt.Errorf("Could not find field %s", name)
+	return reflect.Value{}, grpcStatus.Errorf(codes.InvalidArgument, "Could not find field %s", name)
 }
 
 func copyStructValue(to, from reflect.Value) error {
 	if to.Kind() != reflect.Struct && from.Kind() != reflect.Struct {
-		return fmt.Errorf("Can only copy structs into structs")
+		return grpcStatus.Errorf(codes.InvalidArgument, "Can only copy structs into structs")
 	}
 
 	if copyStructSkipField(to, from) {
@@ -219,7 +221,7 @@ func copyStruct(to interface{}, from interface{}) (err error) {
 
 	if toVal.Kind() != reflect.Ptr || toVal.Elem().Kind() != reflect.Struct ||
 		fromVal.Kind() != reflect.Ptr || fromVal.Elem().Kind() != reflect.Struct {
-		return fmt.Errorf("Arguments must be pointers to structures")
+		return grpcStatus.Errorf(codes.InvalidArgument, "Arguments must be pointers to structures")
 	}
 
 	toVal = toVal.Elem()

--- a/reaper.go
+++ b/reaper.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"sync"
@@ -15,6 +14,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 type reaper struct {
@@ -38,7 +39,7 @@ func (r *reaper) getExitCodeCh(pid int) (chan<- int, error) {
 
 	exitCodeCh, exist := r.exitCodeChans[pid]
 	if !exist {
-		return nil, fmt.Errorf("PID %d not found", pid)
+		return nil, grpcStatus.Errorf(codes.NotFound, "PID %d not found", pid)
 	}
 
 	return exitCodeCh, nil


### PR DESCRIPTION
grpcStatus implements errors returned by gRPC.  These errors are
serialized and transmitted on the wire between server and client, and allow
for additional data to be transmitted via the Details field in the status
proto.  gRPC service handlers should return an error created by this
package, and gRPC clients should expect a corresponding error to be
returned from the RPC call.
