### PR TITLE
protocols: grpc: Rely on exec_id provided by the runtime

### DIFF
--- a/protocols/grpc/agent.proto
+++ b/protocols/grpc/agent.proto
@@ -16,7 +16,7 @@ import "google/protobuf/empty.proto";
 service AgentService {
 	// execution
 	rpc CreateContainer(CreateContainerRequest) returns (google.protobuf.Empty);
-	rpc StartContainer(StartContainerRequest) returns (NewProcessResponse);
+	rpc StartContainer(StartContainerRequest) returns (google.protobuf.Empty);
 
 	// RemoveContainer will tear down an existing container by forcibly terminating
 	// all processes running inside that container and releasing all internal
@@ -25,7 +25,7 @@ service AgentService {
 	// If any process can not be killed or if it can not be killed after
 	// the RemoveContainerRequest timeout, RemoveContainer will return an error.
 	rpc RemoveContainer(RemoveContainerRequest) returns (google.protobuf.Empty);
-	rpc ExecProcess(ExecProcessRequest) returns (NewProcessResponse);
+	rpc ExecProcess(ExecProcessRequest) returns (google.protobuf.Empty);
 	rpc SignalProcess(SignalProcessRequest) returns (google.protobuf.Empty);
 	rpc WaitProcess(WaitProcessRequest) returns (WaitProcessResponse); // wait & reap like waitpid(2)
 
@@ -51,9 +51,10 @@ service AgentService {
 
 message CreateContainerRequest {
 	string container_id = 1;
-	StringUser string_user = 2;
-	repeated Storage storages = 3;
-	Spec OCI = 4;
+	string exec_id = 2;
+	StringUser string_user = 3;
+	repeated Storage storages = 4;
+	Spec OCI = 5;
 }
 
 message StartContainerRequest {
@@ -71,32 +72,26 @@ message RemoveContainerRequest {
 	uint32 timeout = 2;
 }
 
-// NewProcessResponse contains a Linux PID for a process
-// that the agent created and manages.
-// Any gRPC request from the host for a PID that is not managed
-// by the agent will result in an error. For example, calling
-// WaitProcess() with a WaitProcessRequest pid field set to a
-// PID that was not created by the agent will return an error
-// back to the caller.
-message NewProcessResponse {
-	uint32 PID = 1;
-}
-
 message ExecProcessRequest {
 	string container_id = 1;
+	string exec_id = 2;
 	StringUser string_user = 3;
 	Process process = 4;
 }
 
 message SignalProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+
+	// Special case for SignalProcess(): exec_id can be empty(""),
+	// which means to send the signal to all the processes including their descendants.
+	// Other APIs with exec_id should treat empty exec_id as an invalid request.
+	string exec_id = 2;
 	uint32 signal = 3;
 }
 
 message WaitProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message WaitProcessResponse {
@@ -105,7 +100,7 @@ message WaitProcessResponse {
 
 message WriteStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	bytes data = 3;
 }
 
@@ -115,7 +110,7 @@ message WriteStreamResponse {
 
 message ReadStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 len = 3;
 }
 
@@ -125,12 +120,12 @@ message ReadStreamResponse {
 
 message CloseStdinRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message TtyWinResizeRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 row = 3;
 	uint32 column = 4;
 }

--- a/protocols/grpc/health.pb.go
+++ b/protocols/grpc/health.pb.go
@@ -108,7 +108,10 @@ func init() {
 }
 func (this *CheckRequest) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*CheckRequest)
@@ -121,7 +124,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -132,7 +138,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 }
 func (this *HealthCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*HealthCheckResponse)
@@ -145,7 +154,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -156,7 +168,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 }
 func (this *VersionCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*VersionCheckResponse)
@@ -169,7 +184,10 @@ func (this *VersionCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}

--- a/protocols/grpc/oci.pb.go
+++ b/protocols/grpc/oci.pb.go
@@ -1499,7 +1499,10 @@ func init() {
 }
 func (this *Spec) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Spec)
@@ -1512,7 +1515,10 @@ func (this *Spec) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1560,7 +1566,10 @@ func (this *Spec) Equal(that interface{}) bool {
 }
 func (this *Process) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Process)
@@ -1573,7 +1582,10 @@ func (this *Process) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1632,7 +1644,10 @@ func (this *Process) Equal(that interface{}) bool {
 }
 func (this *Box) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Box)
@@ -1645,7 +1660,10 @@ func (this *Box) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1659,7 +1677,10 @@ func (this *Box) Equal(that interface{}) bool {
 }
 func (this *User) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*User)
@@ -1672,7 +1693,10 @@ func (this *User) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1697,7 +1721,10 @@ func (this *User) Equal(that interface{}) bool {
 }
 func (this *LinuxCapabilities) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCapabilities)
@@ -1710,7 +1737,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1758,7 +1788,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 }
 func (this *POSIXRlimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*POSIXRlimit)
@@ -1771,7 +1804,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1788,7 +1824,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 }
 func (this *Mount) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Mount)
@@ -1801,7 +1840,10 @@ func (this *Mount) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1826,7 +1868,10 @@ func (this *Mount) Equal(that interface{}) bool {
 }
 func (this *Root) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Root)
@@ -1839,7 +1884,10 @@ func (this *Root) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1853,7 +1901,10 @@ func (this *Root) Equal(that interface{}) bool {
 }
 func (this *Hooks) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hooks)
@@ -1866,7 +1917,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1898,7 +1952,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 }
 func (this *Hook) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hook)
@@ -1911,7 +1968,10 @@ func (this *Hook) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1941,7 +2001,10 @@ func (this *Hook) Equal(that interface{}) bool {
 }
 func (this *Linux) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Linux)
@@ -1954,7 +2017,10 @@ func (this *Linux) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2036,7 +2102,10 @@ func (this *Linux) Equal(that interface{}) bool {
 }
 func (this *Windows) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Windows)
@@ -2049,7 +2118,10 @@ func (this *Windows) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2060,7 +2132,10 @@ func (this *Windows) Equal(that interface{}) bool {
 }
 func (this *Solaris) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Solaris)
@@ -2073,7 +2148,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2084,7 +2162,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 }
 func (this *LinuxIDMapping) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIDMapping)
@@ -2097,7 +2178,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2114,7 +2198,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 }
 func (this *LinuxNamespace) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNamespace)
@@ -2127,7 +2214,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2141,7 +2231,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 }
 func (this *LinuxDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDevice)
@@ -2154,7 +2247,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2183,7 +2279,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxResources) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxResources)
@@ -2196,7 +2295,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2235,7 +2337,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 }
 func (this *LinuxMemory) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxMemory)
@@ -2248,7 +2353,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2277,7 +2385,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 }
 func (this *LinuxCPU) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCPU)
@@ -2290,7 +2401,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2319,7 +2433,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 }
 func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxWeightDevice)
@@ -2332,7 +2449,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2352,7 +2472,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxThrottleDevice)
@@ -2365,7 +2488,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2382,7 +2508,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxBlockIO) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxBlockIO)
@@ -2395,7 +2524,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2449,7 +2581,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 }
 func (this *LinuxPids) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxPids)
@@ -2462,7 +2597,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2473,7 +2611,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 }
 func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDeviceCgroup)
@@ -2486,7 +2627,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2509,7 +2653,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 }
 func (this *LinuxNetwork) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNetwork)
@@ -2522,7 +2669,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2541,7 +2691,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 }
 func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxHugepageLimit)
@@ -2554,7 +2707,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2568,7 +2724,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 }
 func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxInterfacePriority)
@@ -2581,7 +2740,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2595,7 +2757,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccomp) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccomp)
@@ -2608,7 +2773,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2635,7 +2803,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccompArg)
@@ -2648,7 +2819,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2668,7 +2842,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 }
 func (this *LinuxSyscall) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSyscall)
@@ -2681,7 +2858,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2708,7 +2888,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 }
 func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIntelRdt)
@@ -2721,7 +2904,10 @@ func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}


### PR DESCRIPTION
    protocols: grpc: Rely on exec_id provided by the runtime
    
    This commit radically changes the way the process IDs are generated.
    Indeed, for simplicity, the process ID, called exec_id, will always
    be provided by the runtime.
    
    The shim needs to be started knowing which exec_id it actually
    represents. By having this information from the runtime, we make
    things simple since the runtime will provide this directly to the
    shim, with no need to interact with the agent.
    
    Also, this commit stores the exitCode channel from the caller, so
    that we don't need to keep it into a specific map for too long. This
    prevents from the issue of continuing to use a map with a specific
    PID entry, while this PID could have been re-assigned by the kernel.
    
    Fixes #82
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>