### PR TITLE
test: Increase unit test coverage

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,222 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testExecID      = "testExecID"
+	testContainerID = "testContainerID"
+)
+
+func TestClosePostStartFDsAllNil(t *testing.T) {
+	p := &process{}
+
+	p.closePostStartFDs()
+}
+
+func TestClosePostStartFDsAllInitialized(t *testing.T) {
+	rStdin, wStdin, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStdin.Close()
+
+	rStdout, wStdout, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStdout.Close()
+
+	rStderr, wStderr, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStderr.Close()
+
+	rConsoleSocket, wConsoleSocket, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wConsoleSocket.Close()
+
+	rConsoleSock, wConsoleSock, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wConsoleSock.Close()
+
+	p := &process{
+		process: libcontainer.Process{
+			Stdin:         rStdin,
+			Stdout:        wStdout,
+			Stderr:        wStderr,
+			ConsoleSocket: rConsoleSocket,
+		},
+		consoleSock: rConsoleSock,
+	}
+
+	p.closePostStartFDs()
+}
+
+func TestClosePostExitFDsAllNil(t *testing.T) {
+	p := &process{}
+
+	p.closePostExitFDs()
+}
+
+func TestClosePostExitFDsAllInitialized(t *testing.T) {
+	rTermMaster, wTermMaster, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wTermMaster.Close()
+
+	rStdin, wStdin, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStdin.Close()
+
+	rStdout, wStdout, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStdout.Close()
+
+	rStderr, wStderr, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStderr.Close()
+
+	p := &process{
+		termMaster: rTermMaster,
+		stdin:      wStdin,
+		stdout:     rStdout,
+		stderr:     rStderr,
+	}
+
+	p.closePostExitFDs()
+}
+
+func TestSetProcess(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.setProcess(testExecID, p)
+
+	proc, exist := c.processes[testExecID]
+	assert.True(t, exist, "Process entry should exist")
+
+	assert.True(t, reflect.DeepEqual(p, proc),
+		"Process structures should be identical: got %+v, expecting %+v",
+		proc, p)
+}
+
+func TestDeleteProcess(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.processes[testExecID] = p
+
+	c.deleteProcess(testExecID)
+
+	_, exist := c.processes[testExecID]
+	assert.False(t, exist, "Process entry should not exist")
+}
+
+func TestGetProcessEntryExist(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.processes[testExecID] = p
+
+	proc, err := c.getProcess(testExecID)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, reflect.DeepEqual(p, proc),
+		"Process structures should be identical: got %+v, expecting %+v",
+		proc, p)
+}
+
+func TestGetProcessNoEntry(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	_, err := c.getProcess(testExecID)
+	assert.Error(t, err, "Should fail because no entry has been created")
+}
+
+func TestGetContainerEntryExist(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.containers[testContainerID] = c
+
+	cont, err := s.getContainer(testContainerID)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, reflect.DeepEqual(c, cont),
+		"Container structures should be identical: got %+v, expecting %+v",
+		cont, c)
+}
+
+func TestGetContainerNoEntry(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	_, err := s.getContainer(testContainerID)
+	assert.Error(t, err, "Should fail because no entry has been created")
+}
+
+func TestSetContainer(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.setContainer(testContainerID, c)
+
+	cont, exist := s.containers[testContainerID]
+	assert.True(t, exist, "Container entry should exist")
+
+	assert.True(t, reflect.DeepEqual(c, cont),
+		"Container structures should be identical: got %+v, expecting %+v",
+		cont, c)
+}
+
+func TestDeleteContainer(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.containers[testContainerID] = c
+
+	s.deleteContainer(testContainerID)
+
+	_, exist := s.containers[testContainerID]
+	assert.False(t, exist, "Process entry should not exist")
+}

--- a/api.go
+++ b/api.go
@@ -19,9 +19,10 @@ const (
 
 // VSock
 const (
-	vSockDevPath = "/dev/vsock"
-	vSockPort    = 1024
+	vSockPort = 1024
 )
+
+var vSockDevPath = "/dev/vsock"
 
 // Signals
 const (

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVSockPathExistTrue(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+	fileName := tmpFile.Name()
+	defer tmpFile.Close()
+	defer os.Remove(fileName)
+
+	vSockDevPath = fileName
+
+	result, err := vSockPathExist()
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, result, "VSOCK should be found")
+}
+
+func TestVSockPathExistFalse(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+
+	fileName := tmpFile.Name()
+	tmpFile.Close()
+	err = os.Remove(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	vSockDevPath = fileName
+
+	result, err := vSockPathExist()
+	assert.Nil(t, err, "%v", err)
+
+	assert.False(t, result, "VSOCK should not be found")
+}
+
+func TestSetupVSockChannel(t *testing.T) {
+	c := &vSockChannel{}
+
+	err := c.setup()
+	assert.Nil(t, err, "%v", err)
+}
+
+func TestTeardownVSockChannel(t *testing.T) {
+	c := &vSockChannel{}
+
+	err := c.teardown()
+	assert.Nil(t, err, "%v", err)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	testLogLevel := logrus.DebugLevel
+
+	expectedConfig := agentConfig{
+		logLevel: testLogLevel,
+	}
+
+	config := newConfig(testLogLevel)
+
+	assert.True(t, reflect.DeepEqual(config, expectedConfig),
+		"Config structures should be identical: got %+v, expecting %+v",
+		config, expectedConfig)
+}
+
+func TestParseCmdlineOptionEmptyOption(t *testing.T) {
+	a := &agentConfig{}
+
+	err := a.parseCmdlineOption("")
+	assert.Nil(t, err, "%v", err)
+}
+
+func TestParseCmdlineOptionWrongOptionValue(t *testing.T) {
+	a := &agentConfig{}
+
+	wrongOption := logLevelFlag + "=debgu"
+
+	err := a.parseCmdlineOption(wrongOption)
+	assert.Error(t, err, "Parsing should fail because wrong option %q", wrongOption)
+}
+
+func TestParseCmdlineOptionWrongOptionParam(t *testing.T) {
+	a := &agentConfig{}
+
+	wrongOption := "agent.lgo=debug"
+
+	err := a.parseCmdlineOption(wrongOption)
+	assert.Error(t, err, "Parsing should fail because wrong option %q", wrongOption)
+}
+
+func TestParseCmdlineOptionCorrectOptions(t *testing.T) {
+	a := &agentConfig{}
+
+	logFlagList := []string{"debug", "info", "warn", "error", "fatal", "panic"}
+
+	for _, logFlag := range logFlagList {
+		option := logLevelFlag + "=" + logFlag
+
+		err := a.parseCmdlineOption(option)
+		assert.Nil(t, err, "%v", err)
+	}
+}
+
+func TestParseCmdlineOptionIncorrectOptions(t *testing.T) {
+	a := &agentConfig{}
+
+	logFlagList := []string{"debg", "ifo", "wan", "eror", "ftal", "pnic"}
+
+	for _, logFlag := range logFlagList {
+		option := logLevelFlag + "=" + logFlag
+
+		err := a.parseCmdlineOption(option)
+		assert.Error(t, err, "Should fail because of incorrect option %q", logFlag)
+	}
+}
+
+func TestGetConfigEmptyFileName(t *testing.T) {
+	a := &agentConfig{}
+
+	err := a.getConfig("")
+	assert.Error(t, err, "Should fail because command line path is empty")
+}
+
+func TestGetConfigFilePathNotExist(t *testing.T) {
+	a := &agentConfig{}
+
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+
+	fileName := tmpFile.Name()
+	tmpFile.Close()
+	err = os.Remove(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	err = a.getConfig(fileName)
+	assert.Error(t, err, "Should fail because command line path does not exist")
+}
+
+func TestGetConfig(t *testing.T) {
+	a := &agentConfig{}
+
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+	fileName := tmpFile.Name()
+
+	tmpFile.Write([]byte(logLevelFlag + "=info"))
+	tmpFile.Close()
+
+	defer os.Remove(fileName)
+
+	err = a.getConfig(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, a.logLevel == logrus.InfoLevel,
+		"Log levels should be identical: got %+v, expecting %+v",
+		a.logLevel, logrus.InfoLevel)
+}


### PR DESCRIPTION
    test: Increase unit test coverage
    
    This commit adds some unit tests to cover few functions from the
    following files: agent.go, channel.go and config.go.
    
    Fixes #86
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>