### PR TITLE
agent: Close appropriate file handler

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -95,11 +95,11 @@ func (p *process) closePostStartFDs() {
 	}
 
 	if p.process.ConsoleSocket != nil {
-		p.process.Stderr.(*os.File).Close()
+		p.process.ConsoleSocket.Close()
 	}
 
 	if p.consoleSock != nil {
-		p.process.Stderr.(*os.File).Close()
+		p.consoleSock.Close()
 	}
 }
 


### PR DESCRIPTION
    agent: Close appropriate file handler
    
    This commit fixes a bug in the code of agent.go file. It closes the
    appropriate file handlers after they have been properly tested.
    
    Fixes #88
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>