### PR TITLE
grpc: Return nil from SignalProcess() if container already stopped

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -550,6 +550,7 @@ func (a *agentGRPC) SignalProcess(ctx context.Context, req *pb.SignalProcessRequ
 			"sandbox":     a.sandbox.id,
 			"signal":      signal.String(),
 		}).Info("discarding signal as container stopped")
+		return emptyResp, nil
 	}
 
 	// If the exec ID provided is empty, let's apply the signal to all


### PR DESCRIPTION
There is no need to try to signal a container already stopped.
Only need to return nil in that case.

Fixes: #96

Signed-off-by: Malhar Vora <mlvora.2010@gmail.com>