### PR TITLE
grpc: Fix not online Mem

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -83,8 +83,8 @@ func onlineCPUMem() error {
 				continue
 			}
 
-			cpuOnlinePath := filepath.Join(sysfsCPUOnlinePath, file.Name(), "online")
-			ioutil.WriteFile(cpuOnlinePath, []byte("1"), 0600)
+			onlinePath := filepath.Join(resource.sysfsOnlinePath, file.Name(), "online")
+			ioutil.WriteFile(onlinePath, []byte("1"), 0600)
 		}
 	}
 


### PR DESCRIPTION
In grpc onlineCPUMem(), it just online CPU. I think this is not appropriate. Add online Mem.
Fixes #109 
Signed-off-by: Ruidong Cao <caoruidong@huawei.com>