### PR TITLE
Changes to add ppc64le support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM centos:7
 
 ARG http_proxy
 ARG https_proxy
+ARG arch
 
 # TODO: if you have trouble downloading git repos due to cert problem
 # try to uncomment this
@@ -22,7 +23,7 @@ RUN yum makecache && yum install -y \
 
 # install GO development environment
 ENV GO_VERSION 1.9.2
-RUN curl -fkL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz \
+RUN curl -fkL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-$(arch).tar.gz \
 	| tar -zxC /usr/local/
 ENV GOPATH /go
 ENV PATH $PATH:/go/bin:/usr/local/go/bin

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,12 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT_NO_SHORT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+ARCH := $(shell go env GOARCH)
 
 # args for building agent image
 BUILDARGS := $(if $(http_proxy), --build-arg http_proxy=$(http_proxy))
 BUILDARGS += $(if $(https_proxy), --build-arg https_proxy=$(https_proxy))
+BUILDARGS += $(if $(ARCH), --build-arg arch=$(ARCH))
 AGENT_IMAGE := katacontainers/agent-dev
 AGENT_TAG := $(if $(COMMIT_NO_SHORT),$(COMMIT_NO_SHORT),dev)
 


### PR DESCRIPTION
Changes to add ppc64le support.

1. Passing arch varaible as build arg to Dockerfile.
2. Changes Dockerfile to pull correct golang tar ball.

Signed-off-by: Basheer K <basheer@linux.vnet.ibm.com>