### PR TITLE
agent: Fix the amount of bytes transmitted to the shim

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -230,11 +230,12 @@ func (s *sandbox) readStdio(cid, execID string, length int, stdout bool) ([]byte
 
 	buf := make([]byte, length)
 
-	if _, err := file.Read(buf); err != nil {
+	bytesRead, err := file.Read(buf)
+	if err != nil {
 		return nil, err
 	}
 
-	return buf, nil
+	return buf[:bytesRead], nil
 }
 
 // setupSharedPidNs will reexec this binary in order to execute the C routine


### PR DESCRIPTION
Every time our GRPC functions ReadStdout() or ReadStderr() were
called, the entire allocated buffer was returned. This is wrong
since we don't know the amount of bytes we will get on both stdout
and stderr. Instead, this patch returns the slice corresponding to
the real amount of bytes read from the process.

Fixes #123
Fixes https://github.com/kata-containers/runtime/issues/20

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>