### PR TITLE
grpc: initial changes for networking protocol

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -716,44 +716,28 @@ func (a *agentGRPC) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRe
 	return emptyResp, nil
 }
 
-func (a *agentGRPC) AddInterface(ctx context.Context, req *pb.AddInterfaceRequest) (*gpb.Empty, error) {
-	if err := a.sandbox.addInterface(nil, req.Interface); err != nil {
-		return emptyResp, err
-	}
+func (a *agentGRPC) AddInterface(ctx context.Context, req *pb.AddInterfaceRequest) (*pb.Interface, error) {
+	return a.sandbox.addInterface(nil, req.Interface)
+}
 
+func (a *agentGRPC) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*pb.Interface, error) {
+	return a.sandbox.updateInterface(nil, req.Interface)
+}
+
+func (a *agentGRPC) RemoveInterface(ctx context.Context, req *pb.RemoveInterfaceRequest) (*pb.Interface, error) {
+	return a.sandbox.removeInterface(nil, req.Interface)
+}
+
+func (a *agentGRPC) AddRoute(ctx context.Context, req *pb.AddRouteRequest) (*gpb.Empty, error) {
+	return emptyResp, a.sandbox.addRoute(nil, req.Route)
+}
+
+func (a *agentGRPC) UpdateRoute(ctx context.Context, req *pb.UpdateRouteRequest) (*gpb.Empty, error) {
 	return emptyResp, nil
 }
 
-func (a *agentGRPC) RemoveInterface(ctx context.Context, req *pb.RemoveInterfaceRequest) (*gpb.Empty, error) {
-	if err := a.sandbox.removeInterface(nil, req.Name); err != nil {
-		return emptyResp, err
-	}
-
-	return emptyResp, nil
-}
-
-func (a *agentGRPC) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*gpb.Empty, error) {
-	if err := a.sandbox.updateInterface(nil, req.Interface, req.Type); err != nil {
-		return emptyResp, err
-	}
-
-	return emptyResp, nil
-}
-
-func (a *agentGRPC) AddRoute(ctx context.Context, req *pb.RouteRequest) (*gpb.Empty, error) {
-	if err := a.sandbox.addRoute(nil, req.Route); err != nil {
-		return emptyResp, err
-	}
-
-	return emptyResp, nil
-}
-
-func (a *agentGRPC) RemoveRoute(ctx context.Context, req *pb.RouteRequest) (*gpb.Empty, error) {
-	if err := a.sandbox.removeRoute(nil, req.Route); err != nil {
-		return emptyResp, err
-	}
-
-	return emptyResp, nil
+func (a *agentGRPC) RemoveRoute(ctx context.Context, req *pb.RemoveRouteRequest) (*gpb.Empty, error) {
+	return emptyResp, a.sandbox.removeRoute(nil, req.Route)
 }
 
 func (a *agentGRPC) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*gpb.Empty, error) {

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	pb "github.com/kata-containers/agent/protocols/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+func TestUpdateRemoveInterface(t *testing.T) {
+
+	s := sandbox{}
+
+	ifc := pb.Interface{
+		Name:   "enoNumber",
+		Mtu:    1500,
+		HwAddr: "02:00:ca:fe:00:48",
+	}
+	ip := pb.IPAddress{
+		Family:  0,
+		Address: "192.168.0.101",
+		Mask:    "24",
+	}
+	ifc.IPAddresses = append(ifc.IPAddresses, &ip)
+
+	netHandle, _ := netlink.NewHandle()
+	defer netHandle.Delete()
+
+	//
+	// Initial test: try to update a device which doens't exist:
+	//
+	_, err := s.updateInterface(netHandle, &ifc)
+	assert.NotNil(t, err, "Expected to observe interface couldn't be found error")
+
+	// create a dummy link that we can test update on
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x48}
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			MTU:          1500,
+			TxQLen:       -1,
+			Name:         "ifc-name",
+			HardwareAddr: macAddr,
+		},
+	}
+	netHandle.LinkAdd(link)
+	netHandle.LinkSetUp(link)
+
+	//
+	// With a link populated, check to see if we can successfully update:
+	//
+	resultingIfc, err := s.updateInterface(netHandle, &ifc)
+	assert.Nil(t, err, "Unexpected update interface failure: %v", err)
+	assert.True(t, reflect.DeepEqual(resultingIfc, &ifc),
+		"Interface created didn't match: got %+v, expecting %+v", resultingIfc, ifc)
+
+	// Try with a different valid MTU.  Make sure we can assign a new set of IP addresses
+	ifc.Mtu = 500
+	ifc.IPAddresses[0].Address = "192.168.0.102"
+	ip2 := pb.IPAddress{0, "182.168.0.103", "24"}
+	ifc.IPAddresses = append(ifc.IPAddresses, &ip2)
+
+	resultingIfc, err = s.updateInterface(netHandle, &ifc)
+	assert.Nil(t, err, "Unexpected update interface failure: %v", err)
+	assert.True(t, reflect.DeepEqual(resultingIfc, &ifc),
+		"Interface created didn't match: got %+v, expecting %+v", resultingIfc, ifc)
+
+	// Try with garbage:
+	//
+	ifc.Mtu = 999999999999
+	resultingIfc, err = s.updateInterface(netHandle, &ifc)
+	// expecting this failed
+	assert.NotNil(t, err, "Expected failure")
+
+	ifc.Mtu = 500
+	assert.True(t, reflect.DeepEqual(resultingIfc, &ifc),
+		"Resulting inteface should have been unchanged: got %+v, expecting %+v", resultingIfc, ifc)
+
+	//
+	// Test adding routes:
+	//
+	route := pb.Route{
+		Dest:    "192.168.3.0/24",
+		Gateway: "192.168.0.1",
+		Device:  "enoNumber",
+	}
+	err = s.addRoute(netHandle, &route)
+	assert.Nil(t, err, "add route failed: %v", err)
+
+	//
+	// Test remove routes:
+	//
+	err = s.removeRoute(netHandle, &route)
+	assert.Nil(t, err, "remove route failed: %v", err)
+
+	//
+	// Exercise the removeInterface code:
+	//
+	_, err = s.removeInterface(netHandle, &ifc)
+	assert.Nil(t, err, "remove interface failed: %v", err)
+
+	// Try to remove non existent interface:
+	_, err = s.removeInterface(netHandle, &ifc)
+	assert.NotNil(t, err, "Expected failed removal: %v", err)
+}

--- a/protocols/grpc/agent.pb.go
+++ b/protocols/grpc/agent.pb.go
@@ -28,10 +28,12 @@
 		IPAddress
 		Interface
 		Route
+		UpdateInterfaceRequest
 		AddInterfaceRequest
 		RemoveInterfaceRequest
-		UpdateInterfaceRequest
-		RouteRequest
+		AddRouteRequest
+		UpdateRouteRequest
+		RemoveRouteRequest
 		OnlineCPUMemRequest
 		Storage
 		StringUser
@@ -113,36 +115,6 @@ func (x IPFamily) String() string {
 	return proto.EnumName(IPFamily_name, int32(x))
 }
 func (IPFamily) EnumDescriptor() ([]byte, []int) { return fileDescriptorAgent, []int{0} }
-
-type UpdateType int32
-
-const (
-	UpdateType_None     UpdateType = 0
-	UpdateType_AddIP    UpdateType = 1
-	UpdateType_RemoveIP UpdateType = 2
-	UpdateType_Name     UpdateType = 4
-	UpdateType_MTU      UpdateType = 8
-)
-
-var UpdateType_name = map[int32]string{
-	0: "None",
-	1: "AddIP",
-	2: "RemoveIP",
-	4: "Name",
-	8: "MTU",
-}
-var UpdateType_value = map[string]int32{
-	"None":     0,
-	"AddIP":    1,
-	"RemoveIP": 2,
-	"Name":     4,
-	"MTU":      8,
-}
-
-func (x UpdateType) String() string {
-	return proto.EnumName(UpdateType_name, int32(x))
-}
-func (UpdateType) EnumDescriptor() ([]byte, []int) { return fileDescriptorAgent, []int{1} }
 
 type CreateContainerRequest struct {
 	ContainerId string      `protobuf:"bytes,1,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
@@ -595,7 +567,7 @@ func (m *IPAddress) GetMask() string {
 type Interface struct {
 	Device      string       `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
 	Name        string       `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	IpAddresses []*IPAddress `protobuf:"bytes,3,rep,name=ipAddresses" json:"ipAddresses,omitempty"`
+	IPAddresses []*IPAddress `protobuf:"bytes,3,rep,name=IPAddresses" json:"IPAddresses,omitempty"`
 	Mtu         uint64       `protobuf:"varint,4,opt,name=mtu,proto3" json:"mtu,omitempty"`
 	HwAddr      string       `protobuf:"bytes,5,opt,name=hwAddr,proto3" json:"hwAddr,omitempty"`
 }
@@ -619,9 +591,9 @@ func (m *Interface) GetName() string {
 	return ""
 }
 
-func (m *Interface) GetIpAddresses() []*IPAddress {
+func (m *Interface) GetIPAddresses() []*IPAddress {
 	if m != nil {
-		return m.IpAddresses
+		return m.IPAddresses
 	}
 	return nil
 }
@@ -672,6 +644,22 @@ func (m *Route) GetDevice() string {
 	return ""
 }
 
+type UpdateInterfaceRequest struct {
+	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
+}
+
+func (m *UpdateInterfaceRequest) Reset()                    { *m = UpdateInterfaceRequest{} }
+func (m *UpdateInterfaceRequest) String() string            { return proto.CompactTextString(m) }
+func (*UpdateInterfaceRequest) ProtoMessage()               {}
+func (*UpdateInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{18} }
+
+func (m *UpdateInterfaceRequest) GetInterface() *Interface {
+	if m != nil {
+		return m.Interface
+	}
+	return nil
+}
+
 type AddInterfaceRequest struct {
 	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
 }
@@ -679,7 +667,7 @@ type AddInterfaceRequest struct {
 func (m *AddInterfaceRequest) Reset()                    { *m = AddInterfaceRequest{} }
 func (m *AddInterfaceRequest) String() string            { return proto.CompactTextString(m) }
 func (*AddInterfaceRequest) ProtoMessage()               {}
-func (*AddInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{18} }
+func (*AddInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{19} }
 
 func (m *AddInterfaceRequest) GetInterface() *Interface {
 	if m != nil {
@@ -689,55 +677,63 @@ func (m *AddInterfaceRequest) GetInterface() *Interface {
 }
 
 type RemoveInterfaceRequest struct {
-	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Interface *Interface `protobuf:"bytes,1,opt,name=interface" json:"interface,omitempty"`
 }
 
 func (m *RemoveInterfaceRequest) Reset()                    { *m = RemoveInterfaceRequest{} }
 func (m *RemoveInterfaceRequest) String() string            { return proto.CompactTextString(m) }
 func (*RemoveInterfaceRequest) ProtoMessage()               {}
-func (*RemoveInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{19} }
+func (*RemoveInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{20} }
 
-func (m *RemoveInterfaceRequest) GetName() string {
-	if m != nil {
-		return m.Name
-	}
-	return ""
-}
-
-type UpdateInterfaceRequest struct {
-	Type      UpdateType `protobuf:"varint,1,opt,name=type,proto3,enum=grpc.UpdateType" json:"type,omitempty"`
-	Interface *Interface `protobuf:"bytes,2,opt,name=interface" json:"interface,omitempty"`
-}
-
-func (m *UpdateInterfaceRequest) Reset()                    { *m = UpdateInterfaceRequest{} }
-func (m *UpdateInterfaceRequest) String() string            { return proto.CompactTextString(m) }
-func (*UpdateInterfaceRequest) ProtoMessage()               {}
-func (*UpdateInterfaceRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{20} }
-
-func (m *UpdateInterfaceRequest) GetType() UpdateType {
-	if m != nil {
-		return m.Type
-	}
-	return UpdateType_None
-}
-
-func (m *UpdateInterfaceRequest) GetInterface() *Interface {
+func (m *RemoveInterfaceRequest) GetInterface() *Interface {
 	if m != nil {
 		return m.Interface
 	}
 	return nil
 }
 
-type RouteRequest struct {
+type AddRouteRequest struct {
 	Route *Route `protobuf:"bytes,1,opt,name=route" json:"route,omitempty"`
 }
 
-func (m *RouteRequest) Reset()                    { *m = RouteRequest{} }
-func (m *RouteRequest) String() string            { return proto.CompactTextString(m) }
-func (*RouteRequest) ProtoMessage()               {}
-func (*RouteRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{21} }
+func (m *AddRouteRequest) Reset()                    { *m = AddRouteRequest{} }
+func (m *AddRouteRequest) String() string            { return proto.CompactTextString(m) }
+func (*AddRouteRequest) ProtoMessage()               {}
+func (*AddRouteRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{21} }
 
-func (m *RouteRequest) GetRoute() *Route {
+func (m *AddRouteRequest) GetRoute() *Route {
+	if m != nil {
+		return m.Route
+	}
+	return nil
+}
+
+type UpdateRouteRequest struct {
+	Route *Route `protobuf:"bytes,1,opt,name=route" json:"route,omitempty"`
+}
+
+func (m *UpdateRouteRequest) Reset()                    { *m = UpdateRouteRequest{} }
+func (m *UpdateRouteRequest) String() string            { return proto.CompactTextString(m) }
+func (*UpdateRouteRequest) ProtoMessage()               {}
+func (*UpdateRouteRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{22} }
+
+func (m *UpdateRouteRequest) GetRoute() *Route {
+	if m != nil {
+		return m.Route
+	}
+	return nil
+}
+
+type RemoveRouteRequest struct {
+	Route *Route `protobuf:"bytes,1,opt,name=route" json:"route,omitempty"`
+}
+
+func (m *RemoveRouteRequest) Reset()                    { *m = RemoveRouteRequest{} }
+func (m *RemoveRouteRequest) String() string            { return proto.CompactTextString(m) }
+func (*RemoveRouteRequest) ProtoMessage()               {}
+func (*RemoveRouteRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{23} }
+
+func (m *RemoveRouteRequest) GetRoute() *Route {
 	if m != nil {
 		return m.Route
 	}
@@ -750,7 +746,7 @@ type OnlineCPUMemRequest struct {
 func (m *OnlineCPUMemRequest) Reset()                    { *m = OnlineCPUMemRequest{} }
 func (m *OnlineCPUMemRequest) String() string            { return proto.CompactTextString(m) }
 func (*OnlineCPUMemRequest) ProtoMessage()               {}
-func (*OnlineCPUMemRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{22} }
+func (*OnlineCPUMemRequest) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{24} }
 
 type Storage struct {
 	Driver     string   `protobuf:"bytes,1,opt,name=driver,proto3" json:"driver,omitempty"`
@@ -763,7 +759,7 @@ type Storage struct {
 func (m *Storage) Reset()                    { *m = Storage{} }
 func (m *Storage) String() string            { return proto.CompactTextString(m) }
 func (*Storage) ProtoMessage()               {}
-func (*Storage) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{23} }
+func (*Storage) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{25} }
 
 func (m *Storage) GetDriver() string {
 	if m != nil {
@@ -809,7 +805,7 @@ type StringUser struct {
 func (m *StringUser) Reset()                    { *m = StringUser{} }
 func (m *StringUser) String() string            { return proto.CompactTextString(m) }
 func (*StringUser) ProtoMessage()               {}
-func (*StringUser) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{24} }
+func (*StringUser) Descriptor() ([]byte, []int) { return fileDescriptorAgent, []int{26} }
 
 func (m *StringUser) GetUid() string {
 	if m != nil {
@@ -851,15 +847,16 @@ func init() {
 	proto.RegisterType((*IPAddress)(nil), "grpc.IPAddress")
 	proto.RegisterType((*Interface)(nil), "grpc.Interface")
 	proto.RegisterType((*Route)(nil), "grpc.Route")
+	proto.RegisterType((*UpdateInterfaceRequest)(nil), "grpc.UpdateInterfaceRequest")
 	proto.RegisterType((*AddInterfaceRequest)(nil), "grpc.AddInterfaceRequest")
 	proto.RegisterType((*RemoveInterfaceRequest)(nil), "grpc.RemoveInterfaceRequest")
-	proto.RegisterType((*UpdateInterfaceRequest)(nil), "grpc.UpdateInterfaceRequest")
-	proto.RegisterType((*RouteRequest)(nil), "grpc.RouteRequest")
+	proto.RegisterType((*AddRouteRequest)(nil), "grpc.AddRouteRequest")
+	proto.RegisterType((*UpdateRouteRequest)(nil), "grpc.UpdateRouteRequest")
+	proto.RegisterType((*RemoveRouteRequest)(nil), "grpc.RemoveRouteRequest")
 	proto.RegisterType((*OnlineCPUMemRequest)(nil), "grpc.OnlineCPUMemRequest")
 	proto.RegisterType((*Storage)(nil), "grpc.Storage")
 	proto.RegisterType((*StringUser)(nil), "grpc.StringUser")
 	proto.RegisterEnum("grpc.IPFamily", IPFamily_name, IPFamily_value)
-	proto.RegisterEnum("grpc.UpdateType", UpdateType_name, UpdateType_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -893,11 +890,12 @@ type AgentServiceClient interface {
 	CloseStdin(ctx context.Context, in *CloseStdinRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	TtyWinResize(ctx context.Context, in *TtyWinResizeRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	// networking
-	AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	AddRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
-	RemoveRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
+	AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error)
+	AddRoute(ctx context.Context, in *AddRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
+	UpdateRoute(ctx context.Context, in *UpdateRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
+	RemoveRoute(ctx context.Context, in *RemoveRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	CreateSandbox(ctx context.Context, in *CreateSandboxRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
 	DestroySandbox(ctx context.Context, in *DestroySandboxRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error)
@@ -1011,8 +1009,8 @@ func (c *agentServiceClient) TtyWinResize(ctx context.Context, in *TtyWinResizeR
 	return out, nil
 }
 
-func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
+func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/AddInterface", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1020,17 +1018,8 @@ func (c *agentServiceClient) AddInterface(ctx context.Context, in *AddInterfaceR
 	return out, nil
 }
 
-func (c *agentServiceClient) RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
-	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveInterface", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
-	out := new(google_protobuf2.Empty)
+func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/UpdateInterface", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1038,7 +1027,16 @@ func (c *agentServiceClient) UpdateInterface(ctx context.Context, in *UpdateInte
 	return out, nil
 }
 
-func (c *agentServiceClient) AddRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
+func (c *agentServiceClient) RemoveInterface(ctx context.Context, in *RemoveInterfaceRequest, opts ...grpc1.CallOption) (*Interface, error) {
+	out := new(Interface)
+	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveInterface", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentServiceClient) AddRoute(ctx context.Context, in *AddRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
 	out := new(google_protobuf2.Empty)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/AddRoute", in, out, c.cc, opts...)
 	if err != nil {
@@ -1047,7 +1045,16 @@ func (c *agentServiceClient) AddRoute(ctx context.Context, in *RouteRequest, opt
 	return out, nil
 }
 
-func (c *agentServiceClient) RemoveRoute(ctx context.Context, in *RouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
+func (c *agentServiceClient) UpdateRoute(ctx context.Context, in *UpdateRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
+	out := new(google_protobuf2.Empty)
+	err := grpc1.Invoke(ctx, "/grpc.AgentService/UpdateRoute", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentServiceClient) RemoveRoute(ctx context.Context, in *RemoveRouteRequest, opts ...grpc1.CallOption) (*google_protobuf2.Empty, error) {
 	out := new(google_protobuf2.Empty)
 	err := grpc1.Invoke(ctx, "/grpc.AgentService/RemoveRoute", in, out, c.cc, opts...)
 	if err != nil {
@@ -1106,11 +1113,12 @@ type AgentServiceServer interface {
 	CloseStdin(context.Context, *CloseStdinRequest) (*google_protobuf2.Empty, error)
 	TtyWinResize(context.Context, *TtyWinResizeRequest) (*google_protobuf2.Empty, error)
 	// networking
-	AddInterface(context.Context, *AddInterfaceRequest) (*google_protobuf2.Empty, error)
-	RemoveInterface(context.Context, *RemoveInterfaceRequest) (*google_protobuf2.Empty, error)
-	UpdateInterface(context.Context, *UpdateInterfaceRequest) (*google_protobuf2.Empty, error)
-	AddRoute(context.Context, *RouteRequest) (*google_protobuf2.Empty, error)
-	RemoveRoute(context.Context, *RouteRequest) (*google_protobuf2.Empty, error)
+	AddInterface(context.Context, *AddInterfaceRequest) (*Interface, error)
+	UpdateInterface(context.Context, *UpdateInterfaceRequest) (*Interface, error)
+	RemoveInterface(context.Context, *RemoveInterfaceRequest) (*Interface, error)
+	AddRoute(context.Context, *AddRouteRequest) (*google_protobuf2.Empty, error)
+	UpdateRoute(context.Context, *UpdateRouteRequest) (*google_protobuf2.Empty, error)
+	RemoveRoute(context.Context, *RemoveRouteRequest) (*google_protobuf2.Empty, error)
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	CreateSandbox(context.Context, *CreateSandboxRequest) (*google_protobuf2.Empty, error)
 	DestroySandbox(context.Context, *DestroySandboxRequest) (*google_protobuf2.Empty, error)
@@ -1337,24 +1345,6 @@ func _AgentService_AddInterface_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
-func _AgentService_RemoveInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RemoveInterfaceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(AgentServiceServer).RemoveInterface(ctx, in)
-	}
-	info := &grpc1.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/grpc.AgentService/RemoveInterface",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).RemoveInterface(ctx, req.(*RemoveInterfaceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _AgentService_UpdateInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateInterfaceRequest)
 	if err := dec(in); err != nil {
@@ -1373,8 +1363,26 @@ func _AgentService_UpdateInterface_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentService_RemoveInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveInterfaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServiceServer).RemoveInterface(ctx, in)
+	}
+	info := &grpc1.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/grpc.AgentService/RemoveInterface",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServiceServer).RemoveInterface(ctx, req.(*RemoveInterfaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _AgentService_AddRoute_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RouteRequest)
+	in := new(AddRouteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -1386,13 +1394,31 @@ func _AgentService_AddRoute_Handler(srv interface{}, ctx context.Context, dec fu
 		FullMethod: "/grpc.AgentService/AddRoute",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).AddRoute(ctx, req.(*RouteRequest))
+		return srv.(AgentServiceServer).AddRoute(ctx, req.(*AddRouteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentService_UpdateRoute_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateRouteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServiceServer).UpdateRoute(ctx, in)
+	}
+	info := &grpc1.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/grpc.AgentService/UpdateRoute",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServiceServer).UpdateRoute(ctx, req.(*UpdateRouteRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _AgentService_RemoveRoute_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RouteRequest)
+	in := new(RemoveRouteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -1404,7 +1430,7 @@ func _AgentService_RemoveRoute_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/grpc.AgentService/RemoveRoute",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentServiceServer).RemoveRoute(ctx, req.(*RouteRequest))
+		return srv.(AgentServiceServer).RemoveRoute(ctx, req.(*RemoveRouteRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1516,16 +1542,20 @@ var _AgentService_serviceDesc = grpc1.ServiceDesc{
 			Handler:    _AgentService_AddInterface_Handler,
 		},
 		{
-			MethodName: "RemoveInterface",
-			Handler:    _AgentService_RemoveInterface_Handler,
-		},
-		{
 			MethodName: "UpdateInterface",
 			Handler:    _AgentService_UpdateInterface_Handler,
 		},
 		{
+			MethodName: "RemoveInterface",
+			Handler:    _AgentService_RemoveInterface_Handler,
+		},
+		{
 			MethodName: "AddRoute",
 			Handler:    _AgentService_AddRoute_Handler,
+		},
+		{
+			MethodName: "UpdateRoute",
+			Handler:    _AgentService_UpdateRoute_Handler,
 		},
 		{
 			MethodName: "RemoveRoute",
@@ -2130,8 +2160,8 @@ func (m *Interface) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintAgent(dAtA, i, uint64(len(m.Name)))
 		i += copy(dAtA[i:], m.Name)
 	}
-	if len(m.IpAddresses) > 0 {
-		for _, msg := range m.IpAddresses {
+	if len(m.IPAddresses) > 0 {
+		for _, msg := range m.IPAddresses {
 			dAtA[i] = 0x1a
 			i++
 			i = encodeVarintAgent(dAtA, i, uint64(msg.Size()))
@@ -2192,6 +2222,34 @@ func (m *Route) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *UpdateInterfaceRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Interface != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
+		n5, err := m.Interface.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	return i, nil
+}
+
 func (m *AddInterfaceRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -2211,11 +2269,11 @@ func (m *AddInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
-		n5, err := m.Interface.MarshalTo(dAtA[i:])
+		n6, err := m.Interface.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n6
 	}
 	return i, nil
 }
@@ -2235,49 +2293,20 @@ func (m *RemoveInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
+	if m.Interface != nil {
 		dAtA[i] = 0xa
 		i++
-		i = encodeVarintAgent(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	return i, nil
-}
-
-func (m *UpdateInterfaceRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *UpdateInterfaceRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Type != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintAgent(dAtA, i, uint64(m.Type))
-	}
-	if m.Interface != nil {
-		dAtA[i] = 0x12
-		i++
 		i = encodeVarintAgent(dAtA, i, uint64(m.Interface.Size()))
-		n6, err := m.Interface.MarshalTo(dAtA[i:])
+		n7, err := m.Interface.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n6
+		i += n7
 	}
 	return i, nil
 }
 
-func (m *RouteRequest) Marshal() (dAtA []byte, err error) {
+func (m *AddRouteRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -2287,7 +2316,7 @@ func (m *RouteRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *RouteRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *AddRouteRequest) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -2296,11 +2325,67 @@ func (m *RouteRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintAgent(dAtA, i, uint64(m.Route.Size()))
-		n7, err := m.Route.MarshalTo(dAtA[i:])
+		n8, err := m.Route.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n7
+		i += n8
+	}
+	return i, nil
+}
+
+func (m *UpdateRouteRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateRouteRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Route != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Route.Size()))
+		n9, err := m.Route.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
+	}
+	return i, nil
+}
+
+func (m *RemoveRouteRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RemoveRouteRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Route != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintAgent(dAtA, i, uint64(m.Route.Size()))
+		n10, err := m.Route.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n10
 	}
 	return i, nil
 }
@@ -2694,8 +2779,8 @@ func (m *Interface) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovAgent(uint64(l))
 	}
-	if len(m.IpAddresses) > 0 {
-		for _, e := range m.IpAddresses {
+	if len(m.IPAddresses) > 0 {
+		for _, e := range m.IPAddresses {
 			l = e.Size()
 			n += 1 + l + sovAgent(uint64(l))
 		}
@@ -2728,6 +2813,16 @@ func (m *Route) Size() (n int) {
 	return n
 }
 
+func (m *UpdateInterfaceRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Interface != nil {
+		l = m.Interface.Size()
+		n += 1 + l + sovAgent(uint64(l))
+	}
+	return n
+}
+
 func (m *AddInterfaceRequest) Size() (n int) {
 	var l int
 	_ = l
@@ -2741,19 +2836,6 @@ func (m *AddInterfaceRequest) Size() (n int) {
 func (m *RemoveInterfaceRequest) Size() (n int) {
 	var l int
 	_ = l
-	l = len(m.Name)
-	if l > 0 {
-		n += 1 + l + sovAgent(uint64(l))
-	}
-	return n
-}
-
-func (m *UpdateInterfaceRequest) Size() (n int) {
-	var l int
-	_ = l
-	if m.Type != 0 {
-		n += 1 + sovAgent(uint64(m.Type))
-	}
 	if m.Interface != nil {
 		l = m.Interface.Size()
 		n += 1 + l + sovAgent(uint64(l))
@@ -2761,7 +2843,27 @@ func (m *UpdateInterfaceRequest) Size() (n int) {
 	return n
 }
 
-func (m *RouteRequest) Size() (n int) {
+func (m *AddRouteRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Route != nil {
+		l = m.Route.Size()
+		n += 1 + l + sovAgent(uint64(l))
+	}
+	return n
+}
+
+func (m *UpdateRouteRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Route != nil {
+		l = m.Route.Size()
+		n += 1 + l + sovAgent(uint64(l))
+	}
+	return n
+}
+
+func (m *RemoveRouteRequest) Size() (n int) {
 	var l int
 	_ = l
 	if m.Route != nil {
@@ -4793,7 +4895,7 @@ func (m *Interface) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IpAddresses", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field IPAddresses", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -4817,8 +4919,8 @@ func (m *Interface) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.IpAddresses = append(m.IpAddresses, &IPAddress{})
-			if err := m.IpAddresses[len(m.IpAddresses)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.IPAddresses = append(m.IPAddresses, &IPAddress{})
+			if err := m.IPAddresses[len(m.IPAddresses)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -5028,6 +5130,89 @@ func (m *Route) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAgent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateInterfaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateInterfaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Interface", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Interface == nil {
+				m.Interface = &Interface{}
+			}
+			if err := m.Interface.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAgent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAgent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *AddInterfaceRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5142,104 +5327,6 @@ func (m *RemoveInterfaceRequest) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAgent
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthAgent
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Name = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipAgent(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthAgent
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowAgent
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: UpdateInterfaceRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: UpdateInterfaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
-			}
-			m.Type = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowAgent
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Type |= (UpdateType(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Interface", wireType)
 			}
 			var msglen int
@@ -5292,7 +5379,7 @@ func (m *UpdateInterfaceRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *RouteRequest) Unmarshal(dAtA []byte) error {
+func (m *AddRouteRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -5315,10 +5402,176 @@ func (m *RouteRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: RouteRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: AddRouteRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RouteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: AddRouteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Route", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Route == nil {
+				m.Route = &Route{}
+			}
+			if err := m.Route.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAgent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAgent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UpdateRouteRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAgent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateRouteRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateRouteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Route", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAgent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAgent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Route == nil {
+				m.Route = &Route{}
+			}
+			if err := m.Route.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAgent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAgent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RemoveRouteRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAgent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RemoveRouteRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RemoveRouteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -5865,81 +6118,79 @@ var (
 func init() { proto.RegisterFile("agent.proto", fileDescriptorAgent) }
 
 var fileDescriptorAgent = []byte{
-	// 1213 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x56, 0xef, 0x4e, 0x1b, 0x47,
-	0x10, 0xcf, 0x61, 0x03, 0xf6, 0xd8, 0x26, 0xce, 0x12, 0xc0, 0x75, 0x22, 0x4a, 0xaf, 0x55, 0x42,
-	0xa3, 0xc6, 0x51, 0x68, 0x15, 0xa9, 0x95, 0xaa, 0xc8, 0x38, 0x14, 0xf9, 0x03, 0xc5, 0x5a, 0x83,
-	0xe8, 0x37, 0xb4, 0xf8, 0x16, 0xe7, 0x5a, 0xdf, 0xed, 0x75, 0x77, 0x0f, 0x70, 0xfb, 0x0a, 0x95,
-	0xfa, 0xa5, 0x8f, 0xd1, 0x07, 0xe9, 0xc7, 0x3c, 0x42, 0xc5, 0x93, 0x54, 0xbb, 0xb7, 0x7b, 0xb6,
-	0xf1, 0x19, 0x14, 0x64, 0xa9, 0x9f, 0xbc, 0x33, 0xb3, 0xfe, 0xed, 0x6f, 0xfe, 0xdc, 0xcc, 0x40,
-	0x89, 0xf4, 0x69, 0x28, 0x1b, 0x11, 0x67, 0x92, 0xa1, 0x7c, 0x9f, 0x47, 0xbd, 0x7a, 0x91, 0xf5,
-	0xfc, 0x44, 0x51, 0x7f, 0xd2, 0x67, 0xac, 0x3f, 0xa0, 0xaf, 0xb4, 0x74, 0x16, 0x9f, 0xbf, 0xa2,
-	0x41, 0x24, 0x87, 0x89, 0xd1, 0xfd, 0xe0, 0xc0, 0x7a, 0x8b, 0x53, 0x22, 0x69, 0x8b, 0x85, 0x92,
-	0xf8, 0x21, 0xe5, 0x98, 0xfe, 0x1a, 0x53, 0x21, 0xd1, 0x67, 0x50, 0xee, 0x59, 0xdd, 0xa9, 0xef,
-	0xd5, 0x9c, 0x2d, 0x67, 0xbb, 0x88, 0x4b, 0xa9, 0xae, 0xed, 0xa1, 0x0d, 0x58, 0xa6, 0x57, 0xb4,
-	0xa7, 0xac, 0x0b, 0xda, 0xba, 0xa4, 0xc4, 0xb6, 0x87, 0x5e, 0x43, 0x49, 0x48, 0xee, 0x87, 0xfd,
-	0xd3, 0x58, 0x50, 0x5e, 0xcb, 0x6d, 0x39, 0xdb, 0xa5, 0x9d, 0x6a, 0x43, 0x51, 0x6b, 0x74, 0xb5,
-	0xe1, 0x58, 0x50, 0x8e, 0x41, 0xa4, 0x67, 0xf4, 0x25, 0x14, 0x84, 0x64, 0x9c, 0xf4, 0xa9, 0xa8,
-	0xe5, 0xb7, 0x72, 0xdb, 0xa5, 0x9d, 0x8a, 0xbd, 0xaf, 0xb5, 0x38, 0x35, 0xa3, 0xa7, 0x90, 0x3b,
-	0x6c, 0xb5, 0x6b, 0x8b, 0x1a, 0x15, 0xcc, 0xad, 0x88, 0xf6, 0xb0, 0x52, 0xbb, 0xdf, 0xc1, 0x5a,
-	0x57, 0x12, 0x2e, 0xef, 0xe1, 0x90, 0x7b, 0x0c, 0xeb, 0x98, 0x06, 0xec, 0xe2, 0x5e, 0xd1, 0xa8,
-	0xc1, 0xb2, 0xf4, 0x03, 0xca, 0x62, 0xa9, 0xa3, 0x51, 0xc1, 0x56, 0x74, 0xff, 0x76, 0x00, 0xed,
-	0x5d, 0xd1, 0x5e, 0x87, 0xb3, 0x1e, 0x15, 0xe2, 0x7f, 0x8a, 0xf0, 0x73, 0x58, 0x8e, 0x12, 0x02,
-	0xb5, 0xbc, 0xbe, 0x6e, 0x02, 0x6c, 0x59, 0x59, 0xab, 0xfb, 0x33, 0x3c, 0xee, 0xfa, 0xfd, 0x90,
-	0x0c, 0xe6, 0xc8, 0x77, 0x1d, 0x96, 0x84, 0xc6, 0xd4, 0x54, 0x2b, 0xd8, 0x48, 0x6e, 0x07, 0xd0,
-	0x09, 0xf1, 0xe5, 0xfc, 0x5e, 0x72, 0x5f, 0xc2, 0xea, 0x04, 0xa2, 0x88, 0x58, 0x28, 0xa8, 0x26,
-	0x20, 0x89, 0x8c, 0x85, 0x06, 0x5b, 0xc4, 0x46, 0x72, 0x3d, 0x40, 0x27, 0xdc, 0x97, 0xb4, 0x2b,
-	0x39, 0x25, 0xc1, 0x3c, 0x5c, 0x45, 0x90, 0xf7, 0x88, 0x24, 0xda, 0xd1, 0x32, 0xd6, 0x67, 0xf7,
-	0x39, 0xac, 0x4e, 0xbc, 0x62, 0x48, 0x55, 0x21, 0x37, 0xa0, 0xa1, 0x46, 0xaf, 0x60, 0x75, 0x74,
-	0x09, 0x3c, 0xc2, 0x94, 0x78, 0xf3, 0x63, 0x63, 0x9e, 0xc8, 0x8d, 0x9e, 0xd8, 0x06, 0x34, 0xfe,
-	0x84, 0xa1, 0x62, 0x59, 0x3b, 0x63, 0xac, 0x0f, 0xe1, 0x51, 0x6b, 0xc0, 0x04, 0xed, 0x4a, 0xcf,
-	0x0f, 0xe7, 0x91, 0x9b, 0xdf, 0x61, 0xf5, 0x48, 0x0e, 0x4f, 0x14, 0x98, 0xf0, 0x7f, 0xa3, 0x73,
-	0xf2, 0x8f, 0xb3, 0x4b, 0xeb, 0x1f, 0x67, 0x97, 0x2a, 0xd3, 0x3d, 0x36, 0x88, 0x83, 0x50, 0x97,
-	0x79, 0x05, 0x1b, 0xc9, 0xfd, 0xcb, 0x81, 0xc7, 0x49, 0xaf, 0xeb, 0x92, 0xd0, 0x3b, 0x63, 0x57,
-	0xf6, 0xf9, 0x3a, 0x14, 0xde, 0x33, 0x21, 0x43, 0x12, 0x50, 0xf3, 0x74, 0x2a, 0x2b, 0x78, 0x2f,
-	0x14, 0xb5, 0x85, 0xad, 0xdc, 0x76, 0x11, 0xab, 0xe3, 0x44, 0xa3, 0xca, 0xdd, 0xde, 0xa8, 0x3e,
-	0x87, 0x8a, 0x48, 0x9e, 0x3a, 0x8d, 0x7c, 0x05, 0xa3, 0x08, 0x15, 0x70, 0xd9, 0x28, 0x3b, 0x4a,
-	0xe7, 0x6e, 0xc0, 0xda, 0x3b, 0x2a, 0x24, 0x67, 0xc3, 0x49, 0x5a, 0x2e, 0x81, 0x62, 0xbb, 0xd3,
-	0xf4, 0x3c, 0x4e, 0x85, 0x40, 0xcf, 0x60, 0xe9, 0x9c, 0x04, 0xfe, 0x60, 0xa8, 0x19, 0xae, 0xec,
-	0xac, 0x24, 0x6f, 0xb6, 0x3b, 0x3f, 0x68, 0x2d, 0x36, 0x56, 0xd5, 0x84, 0x48, 0xf2, 0x17, 0x13,
-	0x27, 0x2b, 0xaa, 0x04, 0x07, 0x44, 0xfc, 0xa2, 0x23, 0x55, 0xc4, 0xfa, 0xac, 0x42, 0x52, 0x6c,
-	0x87, 0x92, 0xf2, 0x73, 0xd2, 0xd3, 0x9f, 0x88, 0x47, 0x2f, 0xfc, 0x9e, 0x8d, 0x82, 0x91, 0xd4,
-	0x3f, 0x75, 0x6c, 0x12, 0x40, 0x7d, 0x56, 0xfd, 0xc7, 0x8f, 0x0c, 0xb9, 0x34, 0x10, 0x0f, 0x2d,
-	0x29, 0x63, 0xc0, 0xe3, 0x77, 0x54, 0x28, 0x03, 0x19, 0xeb, 0x18, 0xe4, 0xb1, 0x3a, 0xaa, 0x07,
-	0xdf, 0x5f, 0xaa, 0x0b, 0xba, 0x97, 0x17, 0xb1, 0x91, 0xdc, 0x03, 0x58, 0xc4, 0x2c, 0x96, 0x49,
-	0x51, 0x52, 0x21, 0x0d, 0x1f, 0x7d, 0x56, 0x1e, 0xf6, 0x89, 0xa4, 0x97, 0x64, 0x68, 0x3d, 0x34,
-	0xe2, 0x18, 0xff, 0xdc, 0x38, 0x7f, 0xf7, 0x1d, 0xac, 0x36, 0x3d, 0x2f, 0xf5, 0xd3, 0xa6, 0xfd,
-	0x25, 0x14, 0x7d, 0xab, 0xd3, 0x2f, 0x8c, 0x1c, 0x48, 0xaf, 0x8e, 0x6e, 0xb8, 0x5f, 0xd9, 0xd9,
-	0x30, 0x05, 0x64, 0xe3, 0xe3, 0x8c, 0xe2, 0xe3, 0x06, 0xb0, 0x7e, 0x1c, 0x79, 0x44, 0x4e, 0xdf,
-	0xfe, 0x02, 0xf2, 0x72, 0x18, 0x51, 0x93, 0x47, 0xd3, 0xb2, 0x93, 0xbb, 0x47, 0xc3, 0x88, 0x62,
-	0x6d, 0x9d, 0x24, 0xb7, 0x70, 0x27, 0xb9, 0xd7, 0x50, 0xd6, 0x11, 0x1b, 0x7d, 0x51, 0x8b, 0x5c,
-	0xc9, 0xc6, 0xaf, 0x52, 0xf2, 0xd7, 0xe4, 0x4a, 0x62, 0x71, 0xd7, 0x60, 0xf5, 0x30, 0x1c, 0xf8,
-	0x21, 0x6d, 0x75, 0x8e, 0x0f, 0xa8, 0xed, 0x35, 0xee, 0x1f, 0x0e, 0x2c, 0x9b, 0x4a, 0xd6, 0x01,
-	0xe5, 0xfe, 0x05, 0xe5, 0x69, 0x41, 0x68, 0x49, 0xf7, 0x52, 0x16, 0xf3, 0x9e, 0x2d, 0x09, 0x23,
-	0x29, 0xfd, 0xb9, 0xd0, 0xce, 0x99, 0x04, 0x24, 0x92, 0x4a, 0x19, 0x8b, 0xa4, 0xcf, 0xc2, 0x64,
-	0xb4, 0x17, 0xb1, 0x15, 0xd1, 0xa7, 0x50, 0x0a, 0x58, 0x1c, 0xca, 0xd3, 0x88, 0xf9, 0xa1, 0x34,
-	0x65, 0x00, 0x5a, 0xd5, 0x51, 0x1a, 0xf7, 0x27, 0x80, 0xd1, 0x38, 0x53, 0x25, 0x14, 0xa7, 0xfd,
-	0x41, 0x1d, 0x95, 0xa6, 0x9f, 0xf6, 0x04, 0x75, 0x44, 0xcf, 0x60, 0x85, 0x78, 0x9e, 0xaf, 0xf0,
-	0xc9, 0x60, 0xdf, 0xf7, 0x92, 0xe2, 0x2c, 0xe2, 0x1b, 0xda, 0x17, 0x75, 0x28, 0xd8, 0xaf, 0x07,
-	0x2d, 0xc1, 0xc2, 0xc5, 0x37, 0xd5, 0x07, 0xfa, 0xf7, 0x4d, 0xd5, 0x79, 0xb1, 0x0b, 0x30, 0xca,
-	0x08, 0x2a, 0x40, 0xfe, 0x47, 0x16, 0xd2, 0xea, 0x03, 0x54, 0x84, 0x45, 0x55, 0x49, 0x9d, 0xaa,
-	0x83, 0xca, 0x50, 0x30, 0xe5, 0xd0, 0xa9, 0x2e, 0xe8, 0x2b, 0x24, 0xa0, 0xd5, 0x3c, 0x5a, 0x86,
-	0xdc, 0xc1, 0xd1, 0x71, 0xb5, 0xb0, 0xf3, 0x27, 0x40, 0xb9, 0xa9, 0x16, 0xb3, 0x2e, 0xe5, 0xfa,
-	0x33, 0xda, 0x87, 0x87, 0x37, 0x56, 0x2d, 0xf4, 0x34, 0xc9, 0x4b, 0xf6, 0x06, 0x56, 0x5f, 0x6f,
-	0x24, 0xab, 0x5b, 0xc3, 0xae, 0x6e, 0x8d, 0x3d, 0xb5, 0xba, 0xa1, 0x3d, 0x58, 0x99, 0xdc, 0x70,
-	0xd0, 0x13, 0xdb, 0x81, 0x32, 0xf6, 0x9e, 0x99, 0x30, 0xfb, 0xf0, 0xf0, 0xc6, 0xb2, 0x63, 0xf9,
-	0x64, 0xef, 0x40, 0x33, 0x81, 0xde, 0x42, 0x69, 0x6c, 0xbb, 0x41, 0xb5, 0x04, 0x64, 0x7a, 0xe1,
-	0x99, 0x09, 0xd0, 0x82, 0xca, 0xc4, 0xc2, 0x81, 0xea, 0xc6, 0x9f, 0x8c, 0x2d, 0x64, 0x26, 0xc8,
-	0x2e, 0x94, 0xc6, 0xe6, 0xbe, 0x65, 0x31, 0xbd, 0x5c, 0xd4, 0x3f, 0xc9, 0xb0, 0x98, 0x21, 0xd8,
-	0x04, 0x30, 0x63, 0xda, 0xf3, 0xc3, 0x14, 0x62, 0x6a, 0x3d, 0x48, 0x21, 0x32, 0x46, 0xfa, 0x5b,
-	0x80, 0x64, 0xba, 0x7a, 0x2c, 0x96, 0x68, 0xc3, 0x06, 0xf4, 0xc6, 0x48, 0xaf, 0xd7, 0xa6, 0x0d,
-	0x53, 0x00, 0x94, 0xf3, 0xfb, 0x00, 0x7c, 0x0f, 0x30, 0x9a, 0xda, 0x16, 0x60, 0x6a, 0x8e, 0xcf,
-	0x8c, 0x63, 0x13, 0xca, 0xe3, 0x33, 0x1a, 0x19, 0x5f, 0x33, 0xe6, 0xf6, 0x6d, 0x10, 0xe3, 0x0d,
-	0xd7, 0x42, 0x64, 0x34, 0xe1, 0xbb, 0x8b, 0x73, 0x84, 0x32, 0x51, 0x9c, 0x1f, 0x03, 0x74, 0xa3,
-	0x11, 0x5b, 0xa0, 0xec, 0xfe, 0x3c, 0x13, 0xe8, 0x0d, 0x14, 0x9a, 0x9e, 0x67, 0xe6, 0xd2, 0x78,
-	0x3f, 0xbd, 0xe3, 0x7f, 0xdf, 0x42, 0x29, 0xa1, 0xfc, 0xf1, 0x7f, 0x6d, 0x41, 0x65, 0x62, 0x61,
-	0xb1, 0xdf, 0x45, 0xd6, 0x16, 0x73, 0x5b, 0xb7, 0x98, 0xdc, 0x2f, 0x6c, 0xb7, 0xc8, 0xdc, 0x3a,
-	0x6e, 0xcb, 0xe9, 0xf8, 0xb8, 0xb0, 0x39, 0xcd, 0x18, 0x21, 0xb3, 0x20, 0x76, 0xcb, 0xff, 0x5c,
-	0x6f, 0x3a, 0x1f, 0xae, 0x37, 0x9d, 0x7f, 0xaf, 0x37, 0x9d, 0xb3, 0x25, 0x6d, 0xfd, 0xfa, 0xbf,
-	0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x72, 0x31, 0x5f, 0xbe, 0x0e, 0x00, 0x00,
+	// 1177 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x56, 0xdd, 0x6e, 0x23, 0x35,
+	0x14, 0x66, 0x9a, 0xfe, 0xe5, 0x24, 0x69, 0xbb, 0xee, 0xb6, 0x0d, 0xd9, 0x55, 0x29, 0x83, 0xb4,
+	0x5b, 0x90, 0x36, 0x2b, 0xca, 0x0a, 0xc4, 0x4a, 0x68, 0xc9, 0x66, 0x4b, 0x95, 0x8b, 0x55, 0x23,
+	0x87, 0xaa, 0xdc, 0x55, 0x6e, 0xec, 0x66, 0x07, 0x92, 0xf1, 0x60, 0x7b, 0xda, 0x06, 0x5e, 0x81,
+	0x4b, 0x1e, 0x83, 0xc7, 0xe0, 0x82, 0xcb, 0x7d, 0x04, 0xd4, 0x27, 0x41, 0xf6, 0xd8, 0x93, 0x49,
+	0x32, 0x29, 0xd0, 0x8d, 0xb4, 0x57, 0xe3, 0x73, 0xec, 0xf9, 0xfc, 0xf9, 0xf8, 0xf8, 0x3b, 0x07,
+	0x4a, 0xa4, 0xc7, 0x42, 0x55, 0x8f, 0x04, 0x57, 0x1c, 0x2d, 0xf6, 0x44, 0xd4, 0xad, 0x15, 0x79,
+	0x37, 0x48, 0x1c, 0xb5, 0x07, 0x3d, 0xce, 0x7b, 0x7d, 0xf6, 0xd4, 0x58, 0xe7, 0xf1, 0xc5, 0x53,
+	0x36, 0x88, 0xd4, 0x30, 0x99, 0xf4, 0xdf, 0x7a, 0xb0, 0xdd, 0x14, 0x8c, 0x28, 0xd6, 0xe4, 0xa1,
+	0x22, 0x41, 0xc8, 0x04, 0x66, 0x3f, 0xc7, 0x4c, 0x2a, 0xf4, 0x31, 0x94, 0xbb, 0xce, 0x77, 0x16,
+	0xd0, 0xaa, 0xb7, 0xe7, 0xed, 0x17, 0x71, 0x29, 0xf5, 0xb5, 0x28, 0xda, 0x81, 0x15, 0x76, 0xcd,
+	0xba, 0x7a, 0x76, 0xc1, 0xcc, 0x2e, 0x6b, 0xb3, 0x45, 0xd1, 0xe7, 0x50, 0x92, 0x4a, 0x04, 0x61,
+	0xef, 0x2c, 0x96, 0x4c, 0x54, 0x0b, 0x7b, 0xde, 0x7e, 0xe9, 0x60, 0xa3, 0xae, 0xa9, 0xd5, 0x3b,
+	0x66, 0xe2, 0x44, 0x32, 0x81, 0x41, 0xa6, 0x63, 0xf4, 0x29, 0xac, 0x4a, 0xc5, 0x05, 0xe9, 0x31,
+	0x59, 0x5d, 0xdc, 0x2b, 0xec, 0x97, 0x0e, 0x2a, 0x6e, 0xbd, 0xf1, 0xe2, 0x74, 0x1a, 0x3d, 0x84,
+	0xc2, 0x71, 0xb3, 0x55, 0x5d, 0x32, 0xa8, 0x60, 0x57, 0x45, 0xac, 0x8b, 0xb5, 0xdb, 0x7f, 0x0e,
+	0x5b, 0x1d, 0x45, 0x84, 0xba, 0xc3, 0x81, 0xfc, 0x13, 0xd8, 0xc6, 0x6c, 0xc0, 0x2f, 0xef, 0x14,
+	0x8d, 0x2a, 0xac, 0xa8, 0x60, 0xc0, 0x78, 0xac, 0x4c, 0x34, 0x2a, 0xd8, 0x99, 0xfe, 0x1f, 0x1e,
+	0xa0, 0xc3, 0x6b, 0xd6, 0x6d, 0x0b, 0xde, 0x65, 0x52, 0xbe, 0xa7, 0x08, 0x3f, 0x86, 0x95, 0x28,
+	0x21, 0x50, 0x5d, 0x34, 0xcb, 0x6d, 0x80, 0x1d, 0x2b, 0x37, 0xeb, 0xff, 0x08, 0xf7, 0x3b, 0x41,
+	0x2f, 0x24, 0xfd, 0x39, 0xf2, 0xdd, 0x86, 0x65, 0x69, 0x30, 0x0d, 0xd5, 0x0a, 0xb6, 0x96, 0xdf,
+	0x06, 0x74, 0x4a, 0x02, 0x35, 0xbf, 0x9d, 0xfc, 0x27, 0xb0, 0x39, 0x86, 0x28, 0x23, 0x1e, 0x4a,
+	0x66, 0x08, 0x28, 0xa2, 0x62, 0x69, 0xc0, 0x96, 0xb0, 0xb5, 0x7c, 0x0a, 0xe8, 0x54, 0x04, 0x8a,
+	0x75, 0x94, 0x60, 0x64, 0x30, 0x8f, 0xa3, 0x22, 0x58, 0xa4, 0x44, 0x11, 0x73, 0xd0, 0x32, 0x36,
+	0x63, 0xff, 0x31, 0x6c, 0x8e, 0xed, 0x62, 0x49, 0x6d, 0x40, 0xa1, 0xcf, 0x42, 0x83, 0x5e, 0xc1,
+	0x7a, 0xe8, 0x13, 0xb8, 0x87, 0x19, 0xa1, 0xf3, 0x63, 0x63, 0xb7, 0x28, 0x8c, 0xb6, 0xd8, 0x07,
+	0x94, 0xdd, 0xc2, 0x52, 0x71, 0xac, 0xbd, 0x0c, 0xeb, 0x63, 0xb8, 0xd7, 0xec, 0x73, 0xc9, 0x3a,
+	0x8a, 0x06, 0xe1, 0x3c, 0xee, 0xe6, 0x57, 0xd8, 0xfc, 0x5e, 0x0d, 0x4f, 0x35, 0x98, 0x0c, 0x7e,
+	0x61, 0x73, 0x3a, 0x9f, 0xe0, 0x57, 0xee, 0x7c, 0x82, 0x5f, 0xe9, 0x9b, 0xee, 0xf2, 0x7e, 0x3c,
+	0x08, 0x4d, 0x9a, 0x57, 0xb0, 0xb5, 0xfc, 0xdf, 0x3d, 0xb8, 0x9f, 0x68, 0x5d, 0x87, 0x84, 0xf4,
+	0x9c, 0x5f, 0xbb, 0xed, 0x6b, 0xb0, 0xfa, 0x86, 0x4b, 0x15, 0x92, 0x01, 0xb3, 0x5b, 0xa7, 0xb6,
+	0x86, 0xa7, 0xa1, 0xac, 0x2e, 0xec, 0x15, 0xf6, 0x8b, 0x58, 0x0f, 0xc7, 0x84, 0xaa, 0x70, 0xbb,
+	0x50, 0x7d, 0x02, 0x15, 0x99, 0x6c, 0x75, 0x16, 0x05, 0x1a, 0x46, 0x13, 0x5a, 0xc5, 0x65, 0xeb,
+	0x6c, 0x6b, 0x9f, 0xbf, 0x03, 0x5b, 0xaf, 0x98, 0x54, 0x82, 0x0f, 0xc7, 0x69, 0xf9, 0x04, 0x8a,
+	0xad, 0x76, 0x83, 0x52, 0xc1, 0xa4, 0x44, 0x8f, 0x60, 0xf9, 0x82, 0x0c, 0x82, 0xfe, 0xd0, 0x30,
+	0x5c, 0x3b, 0x58, 0x4b, 0xf6, 0x6c, 0xb5, 0xbf, 0x33, 0x5e, 0x6c, 0x67, 0xb5, 0x08, 0x91, 0xe4,
+	0x17, 0x1b, 0x27, 0x67, 0xea, 0x0b, 0x1e, 0x10, 0xf9, 0x93, 0x89, 0x54, 0x11, 0x9b, 0xb1, 0x0e,
+	0x49, 0xb1, 0x15, 0x2a, 0x26, 0x2e, 0x48, 0xd7, 0x3c, 0x11, 0xca, 0x2e, 0x83, 0xae, 0x8b, 0x82,
+	0xb5, 0xf4, 0x9f, 0x26, 0x36, 0x09, 0xa0, 0x19, 0x6b, 0xfd, 0x49, 0xc9, 0xa5, 0x81, 0x58, 0x77,
+	0xa4, 0xec, 0x04, 0xce, 0xae, 0xd1, 0xa1, 0x1c, 0xa8, 0xd8, 0xc4, 0x60, 0x11, 0xeb, 0xa1, 0xde,
+	0xf0, 0xcd, 0x95, 0x5e, 0x60, 0xb4, 0xbc, 0x88, 0xad, 0xe5, 0xbf, 0x86, 0x25, 0xcc, 0x63, 0x95,
+	0x24, 0x25, 0x93, 0xca, 0xf2, 0x31, 0x63, 0x7d, 0xc2, 0x1e, 0x51, 0xec, 0x8a, 0x0c, 0xdd, 0x09,
+	0xad, 0x99, 0xe1, 0x5f, 0xc8, 0xf2, 0xf7, 0x8f, 0x60, 0xfb, 0x24, 0xa2, 0x44, 0xb1, 0xf4, 0xa8,
+	0xee, 0xe6, 0x9f, 0x40, 0x31, 0x70, 0x3e, 0xb3, 0xc9, 0xe8, 0x0c, 0xe9, 0xd2, 0xd1, 0x0a, 0xff,
+	0x15, 0x6c, 0x36, 0x28, 0x7d, 0x57, 0x94, 0x23, 0x57, 0x64, 0xde, 0x15, 0xe8, 0x19, 0xac, 0x37,
+	0x28, 0x35, 0x91, 0x1a, 0xbd, 0xa4, 0x25, 0xa1, 0x6d, 0xfb, 0x77, 0x29, 0xf9, 0x3b, 0x59, 0x92,
+	0xcc, 0xf8, 0x5f, 0x01, 0x4a, 0xa2, 0x71, 0x87, 0x1f, 0x13, 0xde, 0xff, 0xf7, 0xc7, 0x2d, 0xd8,
+	0x3c, 0x0e, 0xfb, 0x41, 0xc8, 0x9a, 0xed, 0x93, 0xd7, 0xcc, 0xa9, 0x9a, 0xff, 0x9b, 0x07, 0x2b,
+	0xf6, 0xcd, 0x98, 0xab, 0x13, 0xc1, 0x25, 0x13, 0x69, 0xea, 0x19, 0xcb, 0xa8, 0x36, 0x8f, 0x45,
+	0xd7, 0x25, 0x9f, 0xb5, 0xb4, 0xff, 0x42, 0xaa, 0x61, 0x94, 0x5e, 0x75, 0x62, 0xe9, 0xe4, 0xe0,
+	0x91, 0x0a, 0x78, 0x98, 0x34, 0x11, 0x45, 0xec, 0x4c, 0xf4, 0x11, 0x94, 0x06, 0x3c, 0x0e, 0xd5,
+	0x59, 0xc4, 0x83, 0x50, 0xd9, 0x84, 0x03, 0xe3, 0x6a, 0x6b, 0x8f, 0xff, 0x03, 0xc0, 0xa8, 0x70,
+	0xea, 0x64, 0x8d, 0x53, 0x25, 0xd2, 0x43, 0xed, 0xe9, 0xa5, 0xea, 0xa3, 0x87, 0xe8, 0x11, 0xac,
+	0x11, 0x4a, 0x03, 0x8d, 0x4f, 0xfa, 0x47, 0x01, 0x4d, 0x9e, 0x41, 0x11, 0x4f, 0x78, 0x3f, 0xab,
+	0xc1, 0xaa, 0x7b, 0xa7, 0x68, 0x19, 0x16, 0x2e, 0x9f, 0x6d, 0x7c, 0x60, 0xbe, 0x5f, 0x6e, 0x78,
+	0x07, 0x7f, 0x02, 0x94, 0x1b, 0xba, 0x7d, 0xeb, 0x30, 0x61, 0x1e, 0xdb, 0x11, 0xac, 0x4f, 0x34,
+	0x64, 0xe8, 0x61, 0x12, 0xd3, 0xfc, 0x3e, 0xad, 0xb6, 0x5d, 0x4f, 0x1a, 0xbc, 0xba, 0x6b, 0xf0,
+	0xea, 0x87, 0xba, 0xc1, 0x43, 0x87, 0xb0, 0x36, 0xde, 0x07, 0xa1, 0x07, 0x4e, 0xa7, 0x72, 0xba,
+	0xa3, 0x99, 0x30, 0x47, 0xb0, 0x3e, 0xd1, 0x12, 0x39, 0x3e, 0xf9, 0x9d, 0xd2, 0x4c, 0xa0, 0x17,
+	0x50, 0xca, 0xf4, 0x40, 0xa8, 0x9a, 0x80, 0x4c, 0xb7, 0x45, 0x33, 0x01, 0x9a, 0x50, 0x19, 0x6b,
+	0x4b, 0x50, 0xcd, 0x9e, 0x27, 0xa7, 0x57, 0x99, 0x09, 0xf2, 0x12, 0x4a, 0x99, 0xee, 0xc0, 0xb1,
+	0x98, 0x6e, 0x41, 0x6a, 0x1f, 0xe6, 0xcc, 0xd8, 0x52, 0xd9, 0x00, 0xb0, 0xc5, 0x9c, 0x06, 0x61,
+	0x0a, 0x31, 0xd5, 0x44, 0xa4, 0x10, 0x39, 0x85, 0xff, 0x05, 0x40, 0x52, 0x83, 0x29, 0x8f, 0x15,
+	0xda, 0x71, 0x01, 0x9d, 0x28, 0xfc, 0xb5, 0xea, 0xf4, 0xc4, 0x14, 0x00, 0x13, 0xe2, 0x2e, 0x00,
+	0xdf, 0x00, 0x8c, 0x6a, 0xbb, 0x03, 0x98, 0xaa, 0xf6, 0x33, 0xe3, 0xd8, 0x80, 0x72, 0xb6, 0x92,
+	0x23, 0x7b, 0xd6, 0x9c, 0xea, 0x3e, 0x13, 0xe2, 0x39, 0x94, 0xb3, 0x6a, 0xea, 0x20, 0x72, 0x14,
+	0xb6, 0x36, 0xa9, 0x82, 0xe8, 0x5b, 0x58, 0x9f, 0x90, 0x74, 0x97, 0x95, 0xf9, 0x4a, 0x9f, 0x8b,
+	0x30, 0xa1, 0xc2, 0xe3, 0x79, 0xfd, 0xef, 0x08, 0x5f, 0xc3, 0xaa, 0x93, 0x5f, 0xb4, 0x95, 0x72,
+	0xcf, 0x8a, 0xe3, 0x6d, 0x6f, 0x21, 0xa3, 0xc1, 0x2e, 0x85, 0xa6, 0x65, 0xf9, 0x36, 0x80, 0x8c,
+	0x16, 0xa3, 0x6a, 0x96, 0xf9, 0x7f, 0x02, 0x68, 0x42, 0x65, 0xac, 0x17, 0x72, 0x8f, 0x29, 0xaf,
+	0x41, 0xba, 0x4d, 0x62, 0xc6, 0x5b, 0x17, 0x27, 0x31, 0xb9, 0x0d, 0xcd, 0x6d, 0xb9, 0x94, 0xad,
+	0x0f, 0x2e, 0x11, 0x72, 0x6a, 0xc6, 0x2c, 0x88, 0x97, 0xe5, 0xbf, 0x6e, 0x76, 0xbd, 0xb7, 0x37,
+	0xbb, 0xde, 0xdf, 0x37, 0xbb, 0xde, 0xf9, 0xb2, 0x99, 0xfd, 0xe2, 0x9f, 0x00, 0x00, 0x00, 0xff,
+	0xff, 0xe3, 0xd2, 0x7c, 0x87, 0x19, 0x0f, 0x00, 0x00,
 }

--- a/protocols/grpc/agent.proto
+++ b/protocols/grpc/agent.proto
@@ -37,12 +37,12 @@ service AgentService {
 	rpc TtyWinResize(TtyWinResizeRequest) returns (google.protobuf.Empty);
 
 	// networking
-	rpc AddInterface(AddInterfaceRequest) returns (google.protobuf.Empty);
-	rpc RemoveInterface(RemoveInterfaceRequest) returns (google.protobuf.Empty);
-	rpc UpdateInterface(UpdateInterfaceRequest) returns (google.protobuf.Empty);
-	rpc AddRoute(RouteRequest) returns (google.protobuf.Empty);
-	rpc RemoveRoute(RouteRequest) returns (google.protobuf.Empty);
-
+	rpc AddInterface(AddInterfaceRequest) returns(Interface);
+	rpc UpdateInterface(UpdateInterfaceRequest) returns (Interface);
+	rpc RemoveInterface(RemoveInterfaceRequest) returns (Interface);
+	rpc AddRoute(AddRouteRequest) returns (google.protobuf.Empty);
+	rpc UpdateRoute(UpdateRouteRequest) returns (google.protobuf.Empty);
+	rpc RemoveRoute(RemoveRouteRequest) returns (google.protobuf.Empty);
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	rpc CreateSandbox(CreateSandboxRequest) returns (google.protobuf.Empty);
 	rpc DestroySandbox(DestroySandboxRequest) returns (google.protobuf.Empty);
@@ -154,7 +154,7 @@ message IPAddress {
 message Interface {
 	string device = 1;
 	string name = 2;
-	repeated IPAddress ipAddresses = 3;
+	repeated IPAddress IPAddresses = 3;
 	uint64 mtu = 4;
 	string hwAddr = 5;
 }
@@ -165,12 +165,8 @@ message Route {
 	string device = 3;
 }
 
-enum UpdateType {
-	None = 0;
-	AddIP = 1;
-	RemoveIP = 2;
-	Name = 4;
-	MTU = 8;
+message UpdateInterfaceRequest {
+	Interface interface = 1;
 }
 
 message AddInterfaceRequest {
@@ -178,15 +174,18 @@ message AddInterfaceRequest {
 }
 
 message RemoveInterfaceRequest {
-	string name = 1;
+	Interface interface = 1;
 }
 
-message UpdateInterfaceRequest {
-	UpdateType type = 1;
-	Interface interface = 2;
+message AddRouteRequest {
+	Route route = 1;
 }
 
-message RouteRequest {
+message UpdateRouteRequest {
+	Route route = 1;
+}
+
+message RemoveRouteRequest {
 	Route route = 1;
 }
 

--- a/protocols/grpc/health.pb.go
+++ b/protocols/grpc/health.pb.go
@@ -108,10 +108,7 @@ func init() {
 }
 func (this *CheckRequest) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*CheckRequest)
@@ -124,10 +121,7 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -138,10 +132,7 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 }
 func (this *HealthCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*HealthCheckResponse)
@@ -154,10 +145,7 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -168,10 +156,7 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 }
 func (this *VersionCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*VersionCheckResponse)
@@ -184,10 +169,7 @@ func (this *VersionCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}

--- a/protocols/grpc/oci.pb.go
+++ b/protocols/grpc/oci.pb.go
@@ -1499,10 +1499,7 @@ func init() {
 }
 func (this *Spec) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Spec)
@@ -1515,10 +1512,7 @@ func (this *Spec) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1566,10 +1560,7 @@ func (this *Spec) Equal(that interface{}) bool {
 }
 func (this *Process) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Process)
@@ -1582,10 +1573,7 @@ func (this *Process) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1644,10 +1632,7 @@ func (this *Process) Equal(that interface{}) bool {
 }
 func (this *Box) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Box)
@@ -1660,10 +1645,7 @@ func (this *Box) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1677,10 +1659,7 @@ func (this *Box) Equal(that interface{}) bool {
 }
 func (this *User) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*User)
@@ -1693,10 +1672,7 @@ func (this *User) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1721,10 +1697,7 @@ func (this *User) Equal(that interface{}) bool {
 }
 func (this *LinuxCapabilities) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxCapabilities)
@@ -1737,10 +1710,7 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1788,10 +1758,7 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 }
 func (this *POSIXRlimit) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*POSIXRlimit)
@@ -1804,10 +1771,7 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1824,10 +1788,7 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 }
 func (this *Mount) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Mount)
@@ -1840,10 +1801,7 @@ func (this *Mount) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1868,10 +1826,7 @@ func (this *Mount) Equal(that interface{}) bool {
 }
 func (this *Root) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Root)
@@ -1884,10 +1839,7 @@ func (this *Root) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1901,10 +1853,7 @@ func (this *Root) Equal(that interface{}) bool {
 }
 func (this *Hooks) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Hooks)
@@ -1917,10 +1866,7 @@ func (this *Hooks) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -1952,10 +1898,7 @@ func (this *Hooks) Equal(that interface{}) bool {
 }
 func (this *Hook) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Hook)
@@ -1968,10 +1911,7 @@ func (this *Hook) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2001,10 +1941,7 @@ func (this *Hook) Equal(that interface{}) bool {
 }
 func (this *Linux) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Linux)
@@ -2017,10 +1954,7 @@ func (this *Linux) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2102,10 +2036,7 @@ func (this *Linux) Equal(that interface{}) bool {
 }
 func (this *Windows) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Windows)
@@ -2118,10 +2049,7 @@ func (this *Windows) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2132,10 +2060,7 @@ func (this *Windows) Equal(that interface{}) bool {
 }
 func (this *Solaris) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*Solaris)
@@ -2148,10 +2073,7 @@ func (this *Solaris) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2162,10 +2084,7 @@ func (this *Solaris) Equal(that interface{}) bool {
 }
 func (this *LinuxIDMapping) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxIDMapping)
@@ -2178,10 +2097,7 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2198,10 +2114,7 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 }
 func (this *LinuxNamespace) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxNamespace)
@@ -2214,10 +2127,7 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2231,10 +2141,7 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 }
 func (this *LinuxDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxDevice)
@@ -2247,10 +2154,7 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2279,10 +2183,7 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxResources) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxResources)
@@ -2295,10 +2196,7 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2337,10 +2235,7 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 }
 func (this *LinuxMemory) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxMemory)
@@ -2353,10 +2248,7 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2385,10 +2277,7 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 }
 func (this *LinuxCPU) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxCPU)
@@ -2401,10 +2290,7 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2433,10 +2319,7 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 }
 func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxWeightDevice)
@@ -2449,10 +2332,7 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2472,10 +2352,7 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxThrottleDevice)
@@ -2488,10 +2365,7 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2508,10 +2382,7 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxBlockIO) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxBlockIO)
@@ -2524,10 +2395,7 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2581,10 +2449,7 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 }
 func (this *LinuxPids) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxPids)
@@ -2597,10 +2462,7 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2611,10 +2473,7 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 }
 func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxDeviceCgroup)
@@ -2627,10 +2486,7 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2653,10 +2509,7 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 }
 func (this *LinuxNetwork) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxNetwork)
@@ -2669,10 +2522,7 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2691,10 +2541,7 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 }
 func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxHugepageLimit)
@@ -2707,10 +2554,7 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2724,10 +2568,7 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 }
 func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxInterfacePriority)
@@ -2740,10 +2581,7 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2757,10 +2595,7 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccomp) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSeccomp)
@@ -2773,10 +2608,7 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2803,10 +2635,7 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSeccompArg)
@@ -2819,10 +2648,7 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2842,10 +2668,7 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 }
 func (this *LinuxSyscall) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxSyscall)
@@ -2858,10 +2681,7 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}
@@ -2888,10 +2708,7 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 }
 func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	}
 
 	that1, ok := that.(*LinuxIntelRdt)
@@ -2904,10 +2721,7 @@ func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
+		return this == nil
 	} else if this == nil {
 		return false
 	}

--- a/protocols/mockserver/mockserver.go
+++ b/protocols/mockserver/mockserver.go
@@ -286,7 +286,37 @@ func (m *mockServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxR
 	return &types.Empty{}, nil
 }
 
-func (m *mockServer) AddInterface(context.Context, *pb.AddInterfaceRequest) (*types.Empty, error) {
+func (m *mockServer) AddInterface(context.Context, *pb.AddInterfaceRequest) (*pb.Interface, error) {
+	mockLock.RLock()
+	defer mockLock.RUnlock()
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (m *mockServer) RemoveInterface(context.Context, *pb.RemoveInterfaceRequest) (*pb.Interface, error) {
+	mockLock.RLock()
+	defer mockLock.RUnlock()
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (m *mockServer) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*pb.Interface, error) {
+	mockLock.RLock()
+	defer mockLock.RUnlock()
+	if err := m.podExist(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (m *mockServer) AddRoute(ctx context.Context, req *pb.AddRouteRequest) (*types.Empty, error) {
 	mockLock.RLock()
 	defer mockLock.RUnlock()
 	if err := m.podExist(); err != nil {
@@ -296,7 +326,7 @@ func (m *mockServer) AddInterface(context.Context, *pb.AddInterfaceRequest) (*ty
 	return &types.Empty{}, nil
 }
 
-func (m *mockServer) RemoveInterface(context.Context, *pb.RemoveInterfaceRequest) (*types.Empty, error) {
+func (m *mockServer) UpdateRoute(ctx context.Context, req *pb.UpdateRouteRequest) (*types.Empty, error) {
 	mockLock.RLock()
 	defer mockLock.RUnlock()
 	if err := m.podExist(); err != nil {
@@ -306,7 +336,7 @@ func (m *mockServer) RemoveInterface(context.Context, *pb.RemoveInterfaceRequest
 	return &types.Empty{}, nil
 }
 
-func (m *mockServer) RemoveRoute(context.Context, *pb.RouteRequest) (*types.Empty, error) {
+func (m *mockServer) RemoveRoute(context.Context, *pb.RemoveRouteRequest) (*types.Empty, error) {
 	mockLock.RLock()
 	defer mockLock.RUnlock()
 	if err := m.podExist(); err != nil {
@@ -315,27 +345,6 @@ func (m *mockServer) RemoveRoute(context.Context, *pb.RouteRequest) (*types.Empt
 
 	return &types.Empty{}, nil
 }
-
-func (m *mockServer) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*types.Empty, error) {
-	mockLock.RLock()
-	defer mockLock.RUnlock()
-	if err := m.podExist(); err != nil {
-		return nil, err
-	}
-
-	return &types.Empty{}, nil
-}
-
-func (m *mockServer) AddRoute(ctx context.Context, req *pb.RouteRequest) (*types.Empty, error) {
-	mockLock.RLock()
-	defer mockLock.RUnlock()
-	if err := m.podExist(); err != nil {
-		return nil, err
-	}
-
-	return &types.Empty{}, nil
-}
-
 func (m *mockServer) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*types.Empty, error) {
 	mockLock.RLock()
 	defer mockLock.RUnlock()


### PR DESCRIPTION
WIP changes for making the networking interface gRPC protocol declarative.

### For the proposal in this patch:
The number of messages for route and interface handling is reduced to
two with this patch: UpdateRoutes and UpdateInterfaces.

UpdateInterfaces operates on an array of network-interfaces.  Doing this
allows for removal of interfaces by sending a new update request with
the interface no longer included.  For example, initially
UpdateInterfaces is called for 'A,' 'B' and 'C.'  Later a network remove of
network interface 'B' is carried out by calling UpdateInterfaces with
just 'A' and 'C'.  While this simplifies the protocol and runtime handling, it does put a
burden on the agent to write out the (non-necessarily changed) interface
details for 'A' and 'C' and determine that 'B' was removed.  In the event that network disconnect is used for each of the existing interfaces, a nil array of Interfaces could be sent.  

UpdateRoutes also operates on an array of routes.

This patch doesn't work - just as an example which barely compiles to drive the discussion.

### Alternative approach:

We could allow for explicit removal of interfaces by either:
  1. defining a RemoveInterface message, or 
  2. adding a flag (or type: update|remove) that could be passed to the UpdateInterface function

If these options are used, the agent would work on the (network) interface granularity rather than on all of the interfaces per message call.

### Further details:
* Regardless of which approach we use, the interface or interfaces and routes are returned as well as error status (as discussed already)
* Interfaces will be identified by MAC-address (as discussed already)
