### PR TITLE
enable interruptible and multiple WaitProcess()

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -132,12 +132,14 @@ func (c *container) setProcess(process *process) {
 	c.Unlock()
 }
 
-func (c *container) deleteProcess(process *process) {
+func (c *container) deleteProcess(process *process) bool {
 	c.Lock()
+	defer c.Unlock()
 	if p, ok := c.processes[process.id]; ok && p == process {
 		delete(c.processes, process.id)
+		return true
 	}
-	c.Unlock()
+	return false
 }
 
 func (c *container) removeContainer() error {

--- a/agent.go
+++ b/agent.go
@@ -132,9 +132,11 @@ func (c *container) setProcess(process *process) {
 	c.Unlock()
 }
 
-func (c *container) deleteProcess(execID string) {
+func (c *container) deleteProcess(process *process) {
 	c.Lock()
-	delete(c.processes, execID)
+	if p, ok := c.processes[process.id]; ok && p == process {
+		delete(c.processes, process.id)
+	}
 	c.Unlock()
 }
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -123,7 +123,7 @@ func TestDeleteProcess(t *testing.T) {
 
 	c.processes[testExecID] = p
 
-	c.deleteProcess(testExecID)
+	c.deleteProcess(p)
 
 	_, exist := c.processes[testExecID]
 	assert.False(t, exist, "Process entry should not exist")

--- a/grpc.go
+++ b/grpc.go
@@ -504,7 +504,7 @@ func (a *agentGRPC) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest)
 
 	select {
 	case exitCode := <-proc.exitCodeCh:
-		ctr.deleteProcess(proc.id)
+		ctr.deleteProcess(proc)
 		proc.process.Wait()
 		proc.closePostExitFDs()
 		return &pb.WaitProcessResponse{


### PR DESCRIPTION
In some cases, these might be multiple clients calls to WaitProcess(), this pr enables it.
and some other cases the clients might disconnect while calling WaitProcess(), we need to handle it too.

fixes #129 #130 