### PR TITLE
log: init logrus always before use it

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -483,6 +483,10 @@ func main() {
 		},
 	}
 
+	if err = s.initLogger(); err != nil {
+		return
+	}
+
 	// Check if this agent has been run as the init process.
 	if os.Getpid() == 1 {
 		// pivot_root won't work, see
@@ -492,10 +496,6 @@ func main() {
 			agentLog.WithError(err).Error("initAgentAsInit() failed")
 			panic(fmt.Sprintf("initAgentAsInit() error: %s", err))
 		}
-	}
-
-	if err = s.initLogger(); err != nil {
-		return
 	}
 
 	// Set agent as subreaper.

--- a/reaper.go
+++ b/reaper.go
@@ -64,7 +64,7 @@ func (r *reaper) reap() error {
 		rus unix.Rusage
 	)
 
-	// When running new processes, libcontainer expects to wait
+	// When running new processes, agent expects to wait
 	// for the first process actually spawning the container.
 	// This lock allows any code starting a new process to take
 	// the lock prior to the start of this new process, preventing


### PR DESCRIPTION
Fixes https://github.com/kata-containers/agent/issues/134

Always call `initLogger` before use it, make sure logrus is initialized
correctly when call into `initAgentAsInit()` func.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>