### PR TITLE
lint: Remove unused variables and struct fields

### DIFF
--- a/api.go
+++ b/api.go
@@ -37,7 +37,6 @@ const (
 	agentName       = "kata-agent"
 	exitSuccess     = 0
 	exitFailure     = 1
-	fileMode0750    = 0750
 	defaultLogLevel = logrus.InfoLevel
 	selfBinPath     = "/proc/self/exe"
 )

--- a/grpc.go
+++ b/grpc.go
@@ -51,8 +51,6 @@ type onlineResource struct {
 	regexpPattern   string
 }
 
-var defaultMountFlags = unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV
-
 var emptyResp = &gpb.Empty{}
 
 func onlineCPUMem() error {

--- a/network.go
+++ b/network.go
@@ -26,8 +26,7 @@ type network struct {
 	routesLock sync.Mutex
 	routes     []*pb.Route
 
-	dnsLock sync.Mutex
-	dns     []string
+	dns []string
 }
 
 ////////////////

--- a/protocols/mockserver/mockserver.go
+++ b/protocols/mockserver/mockserver.go
@@ -21,8 +21,6 @@ import (
 const (
 	// MockServerVersion specifies the version of the fake server
 	MockServerVersion = "mock.0.1"
-
-	podStartingPid = 100
 )
 
 // If an rpc changes any pod/container/process, take a write lock.


### PR DESCRIPTION
Remove unused variables and struct fields reported by the `structcheck`
and `unused` linters.

Fixes #136.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>