### PR TITLE
agent: Allow to retrieve the process of a stopped container

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -195,15 +195,12 @@ func (s *sandbox) getProcess(cid, execID string) (*process, *container, error) {
 		return nil, nil, err
 	}
 
-	status, err := ctr.container.Status()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if status == libcontainer.Stopped {
-		return nil, nil, fmt.Errorf("Container %s is stopped", cid)
-	}
-
+	// A container being in stopped state is not a valid reason for not
+	// accepting a call to getProcess(). Indeed, we want to make sure a
+	// shim can connect after the process has already terminated. Some
+	// processes have a very short lifetime and the shim might end up
+	// calling into WaitProcess() after this happened. This does not mean
+	// we cannot retrieve the output and the exit code from the shim.
 	proc, err := ctr.getProcess(execID)
 	if err != nil {
 		return nil, nil, err

--- a/agent_test.go
+++ b/agent_test.go
@@ -220,3 +220,29 @@ func TestDeleteContainer(t *testing.T) {
 	_, exist := s.containers[testContainerID]
 	assert.False(t, exist, "Process entry should not exist")
 }
+
+func TestGetProcessFromSandbox(t *testing.T) {
+	s := &sandbox{
+		running:    true,
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id:        testContainerID,
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.processes[testExecID] = p
+	s.containers[testContainerID] = c
+
+	proc, _, err := s.getProcess(testContainerID, testExecID)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, reflect.DeepEqual(p, proc),
+		"Process structures should be identical: got %+v, expecting %+v",
+		proc, p)
+}


### PR DESCRIPTION
A container being in stopped state is not a valid reason for not
accepting a call to getProcess(). Indeed, the explanation behind
this is that we want to make sure a shim can connect after the
process has already terminated. Some processes have a very short
lifetime and the shim might end up calling into WaitProcess()
after that. This does not mean that we cannot retrieve the output
and the exit code, they are waiting for the shim for that. But we
need to let the shim by not returning an error in this case.

Fixes #145

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>