### PR TITLE
CI: add setup.sh and run.sh to execute integration tests

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+pushd "${tests_repo_dir}"
+.ci/run.sh
+popd

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+clone_tests_repo
+
+pushd "${tests_repo_dir}"
+.ci/setup.sh
+popd


### PR DESCRIPTION
.ci/setup.sh will setup the environment with
latest changes to be able to execute Kata Containers.

.ci/run.sh will execute the integration tests that live
in the 'kata-containers/tests' repository.

Fixes #152.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>