### PR TITLE
logging: Add source log field

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -72,8 +72,9 @@ type namespace struct {
 }
 
 var agentLog = logrus.WithFields(logrus.Fields{
-	"name": agentName,
-	"pid":  os.Getpid(),
+	"name":   agentName,
+	"pid":    os.Getpid(),
+	"source": "agent",
 })
 
 // version is the agent version. This variable is populated at build time.


### PR DESCRIPTION
Add a `source=` log field for parity with the other system components.

Fixes #157.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>