### PR TITLE
main: Display full stacktrace on internal error

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -441,6 +442,9 @@ func initAgentAsInit() error {
 }
 
 func init() {
+	// Force full stacktrace on internal error
+	debug.SetTraceback("system")
+
 	if len(os.Args) > 1 && os.Args[1] == "init" {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()


### PR DESCRIPTION
Enable a full stacktrace display on internal error as an aid to
debugging.

Fixes #160.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>