### PR TITLE
Fix lint errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,8 +43,7 @@ func (c *agentConfig) getConfig(cmdLineFile string) error {
 	}
 
 	words := strings.Fields(string(kernelCmdline))
-	for _, w := range words {
-		word := string(w)
+	for _, word := range words {
 		if err := c.parseCmdlineOption(word); err != nil {
 			agentLog.WithFields(logrus.Fields{
 				"error":  err,

--- a/device.go
+++ b/device.go
@@ -54,7 +54,7 @@ func blockDeviceHandler(device pb.Device, spec *pb.Spec) error {
 		return err
 	}
 
-	dev := uint64(stat.Rdev)
+	dev := stat.Rdev
 
 	major := int64(unix.Major(dev))
 	minor := int64(unix.Minor(dev))

--- a/network_test.go
+++ b/network_test.go
@@ -68,7 +68,11 @@ func TestUpdateRemoveInterface(t *testing.T) {
 	// Try with a different valid MTU.  Make sure we can assign a new set of IP addresses
 	ifc.Mtu = 500
 	ifc.IPAddresses[0].Address = "192.168.0.102"
-	ip2 := pb.IPAddress{0, "182.168.0.103", "24"}
+	ip2 := pb.IPAddress{
+		Family:  0,
+		Address: "182.168.0.103",
+		Mask:    "24",
+	}
 	ifc.IPAddresses = append(ifc.IPAddresses, &ip2)
 
 	resultingIfc, err = s.updateInterface(netHandle, &ifc)

--- a/reaper.go
+++ b/reaper.go
@@ -167,12 +167,6 @@ func (p *reaperOSProcess) wait() {
 	(*os.Process)(p).Wait()
 }
 
-type reaperExecCmd exec.Cmd
-
-func (c *reaperExecCmd) wait() {
-	(*exec.Cmd)(c).Wait()
-}
-
 type reaperLibcontainerProcess libcontainer.Process
 
 func (p *reaperLibcontainerProcess) wait() {


### PR DESCRIPTION
Fix issues identified by `varcheck` and `unconvert` linters.