### PR TITLE
CI: Require pullapprove ack for protocol changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -41,3 +41,16 @@ groups:
           - "*.md"
         exclude:
           - "vendor/*"
+
+  protocol-changes:
+    required: 2
+    teams:
+      - architecture-committee
+      - builder
+      - packaging
+    conditions:
+      files:
+        include:
+          - "*.proto"
+        exclude:
+          - "vendor/*"


### PR DESCRIPTION
A change to any of the gRPC protocol buffer files (`*.proto`) should
require an additional approval due to the potential impact it could
have across the system.

Fixes #175.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>