### PR TITLE
Skip more tests if not root

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -20,6 +20,12 @@ const (
 	testContainerID = "testContainerID"
 )
 
+func skipUnlessRoot(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test disabled as requires root user")
+	}
+}
+
 func TestClosePostStartFDsAllNil(t *testing.T) {
 	p := &process{}
 

--- a/mount_test.go
+++ b/mount_test.go
@@ -31,6 +31,8 @@ func createSafeAndFakeStorage() (pb.Storage, error) {
 }
 
 func TestVirtio9pStorageHandlerSuccessful(t *testing.T) {
+	skipUnlessRoot(t)
+
 	storage, err := createSafeAndFakeStorage()
 	if err != nil {
 		t.Fatal(err)
@@ -46,6 +48,8 @@ func TestVirtio9pStorageHandlerSuccessful(t *testing.T) {
 }
 
 func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
+	skipUnlessRoot(t)
+
 	devPath, err := createFakeDevicePath()
 	if err != nil {
 		t.Fatal(err)

--- a/network_test.go
+++ b/network_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestUpdateRemoveInterface(t *testing.T) {
+	skipUnlessRoot(t)
 
 	s := sandbox{}
 

--- a/network_test.go
+++ b/network_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"net"
-	"os"
 	"reflect"
 	"runtime"
 	"testing"
@@ -100,12 +99,6 @@ func TestUpdateRemoveInterface(t *testing.T) {
 }
 
 type teardownNetworkTest func()
-
-func skipUnlessRoot(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("")
-	}
-}
 
 func setupNetworkTest(t *testing.T) teardownNetworkTest {
 	skipUnlessRoot(t)

--- a/pause_test.go
+++ b/pause_test.go
@@ -17,10 +17,8 @@ import (
 )
 
 func TestForkPauseBin(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("skipping fork pause bin test that requires root")
-		return
-	}
+	skipUnlessRoot(t)
+
 	cmd := &exec.Cmd{
 		Path: selfBinPath,
 		Args: []string{os.Args[0], pauseBinArg},


### PR DESCRIPTION
The unit tests in this repository are ultimately run by the
`go-test.sh` script in the `tests` repository. This script actually runs
the unit-tests *twice* **if** it is invoked as a non-`root` user: once
as the non-`root` user and once as `root`. This is done to cover all
possible scenarios: certain tests require super-user privileges whilst
other tests are only valid when running as a non-privileged user. The
script then combines the test results to calculate a coverage
percentage.

The Travis test runs are currently failing (in the first non-`root`
"run") as some of the tests require root privileges.

Make extra calls to `skipUnlessRoot()` for those failing tests to allow
them to be skipped when run as a non-`root` user and then run as `root`
in the second "run".

Fixes #177.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
