### PR TITLE
device: VmPath can be empty if an Id is provided

### DIFF
--- a/device.go
+++ b/device.go
@@ -310,9 +310,9 @@ func addDevice(device *pb.Device, spec *pb.Spec) error {
 			"invalid type for device %v", device)
 	}
 
-	if device.VmPath == "" {
+	if device.Id == "" && device.VmPath == "" {
 		return grpcStatus.Errorf(codes.InvalidArgument,
-			"invalid VM path for device %v", device)
+			"invalid ID and VM path for device %v", device)
 	}
 
 	if device.ContainerPath == "" {

--- a/device_test.go
+++ b/device_test.go
@@ -248,7 +248,7 @@ func TestAddDevice(t *testing.T) {
 		},
 		{
 			device: &pb.Device{
-				// Missing VmPath
+				// Missing Id and missing VmPath
 				Type:          noopHandlerTag,
 				ContainerPath: "/foo",
 			},
@@ -266,9 +266,20 @@ func TestAddDevice(t *testing.T) {
 		},
 		{
 			device: &pb.Device{
-				// Id is optional
+				// Id is optional if VmPath is provided
 				Type:          noopHandlerTag,
 				VmPath:        "/foo",
+				ContainerPath: "/foo",
+				Options:       []string{},
+			},
+			spec:        emptySpec,
+			expectError: false,
+		},
+		{
+			device: &pb.Device{
+				// VmPath is optional if Id is provided
+				Id:            "foo",
+				Type:          noopHandlerTag,
 				ContainerPath: "/foo",
 				Options:       []string{},
 			},


### PR DESCRIPTION
The statement returning an error in case VmPath is empty is wrong
because an Id can be provided instead. This patch fixes this behavior
and generates an error only if VmPath and Id are both empty.

Fixes #191

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>