### PR TITLE
mount: Correct error message with mount failure.

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -117,7 +117,7 @@ func mount(source, destination, fsType string, flags int, options string) error 
 
 	if err := syscall.Mount(absSource, destination,
 		fsType, uintptr(flags), options); err != nil {
-		return grpcStatus.Errorf(codes.Internal, "Could not bind mount %v to %v: %v",
+		return grpcStatus.Errorf(codes.Internal, "Could not mount %v to %v: %v",
 			absSource, destination, err)
 	}
 


### PR DESCRIPTION
The function mount() performs a generic mount and calls into
mount(2). The current error message is misleading as it refers
to an error in bind-mounting.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>