### PR TITLE
vendor: Update libcontainer vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
     "libcontainer/user",
     "libcontainer/utils"
   ]
-  revision = "e6516b3d5dc780cb57a976013c242a9a93052543"
+  revision = "cc4307ab6643668ce5abc6b524e1764a54c32550"
 
 [[projects]]
   name = "github.com/opencontainers/runtime-spec"
@@ -255,6 +255,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d47e191aaef03b9e18299bdaba587092ca6428b5d6bf7e2cd1dcf8ce51043759"
+  inputs-digest = "93b5fff12a090f22895db2641ba5cd2569bc14a82c2f86e9fe3813f9a5e30cc9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/opencontainers/runc"
-  revision = "e6516b3d5dc780cb57a976013c242a9a93052543"
+  revision = "cc4307ab6643668ce5abc6b524e1764a54c32550"
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"

--- a/vendor/github.com/opencontainers/runc/libcontainer/capabilities_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/capabilities_linux.go
@@ -4,7 +4,6 @@ package libcontainer
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -72,7 +71,7 @@ func newContainerCapList(capConfig *configs.Capabilities) (*containerCapabilitie
 		}
 		ambient = append(ambient, v)
 	}
-	pid, err := capability.NewPid(os.Getpid())
+	pid, err := capability.NewPid(0)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
@@ -161,7 +161,7 @@ func (m *Manager) Apply(pid int) (err error) {
 }
 
 func (m *Manager) Destroy() error {
-	if m.Cgroups.Paths != nil {
+	if m.Cgroups == nil || m.Cgroups.Paths != nil {
 		return nil
 	}
 	m.mu.Lock()

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
 )
 
 type Manager struct {
@@ -295,8 +296,15 @@ func (m *Manager) Apply(pid int) error {
 		}
 	}
 
-	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, nil); err != nil && !isUnitExists(err) {
+	statusChan := make(chan string)
+	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, statusChan); err != nil && !isUnitExists(err) {
 		return err
+	}
+
+	select {
+	case <-statusChan:
+	case <-time.After(time.Second):
+		logrus.Warnf("Timed out while waiting for StartTransientUnit completion signal from dbus. Continuing...")
 	}
 
 	if err := joinCgroups(c, pid); err != nil {
@@ -392,7 +400,7 @@ func joinCgroups(c *configs.Cgroup, pid int) error {
 
 // systemd represents slice hierarchy using `-`, so we need to follow suit when
 // generating the path of slice. Essentially, test-a-b.slice becomes
-// test.slice/test-a.slice/test-a-b.slice.
+// /test.slice/test-a.slice/test-a-b.slice.
 func ExpandSlice(slice string) (string, error) {
 	suffix := ".slice"
 	// Name has to end with ".slice", but can't be just ".slice".
@@ -418,10 +426,9 @@ func ExpandSlice(slice string) (string, error) {
 		}
 
 		// Append the component to the path and to the prefix.
-		path += prefix + component + suffix + "/"
+		path += "/" + prefix + component + suffix
 		prefix += component + "-"
 	}
-
 	return path, nil
 }
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/rootless.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/rootless.go
@@ -49,7 +49,7 @@ func rootlessMappings(config *configs.Config) error {
 		return fmt.Errorf("rootless containers requires at least one UID mapping")
 	}
 	if len(config.GidMappings) == 0 {
-		return fmt.Errorf("rootless containers requires at least one UID mapping")
+		return fmt.Errorf("rootless containers requires at least one GID mapping")
 	}
 
 	return nil

--- a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -5,6 +5,7 @@ package libcontainer
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -267,20 +268,71 @@ func (c *linuxContainer) Exec() error {
 
 func (c *linuxContainer) exec() error {
 	path := filepath.Join(c.root, execFifoFilename)
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
-	if err != nil {
-		return newSystemErrorWithCause(err, "open exec fifo for reading")
+
+	fifoOpen := make(chan struct{})
+	select {
+	case <-awaitProcessExit(c.initProcess.pid(), fifoOpen):
+		return errors.New("container process is already dead")
+	case result := <-awaitFifoOpen(path):
+		close(fifoOpen)
+		if result.err != nil {
+			return result.err
+		}
+		f := result.file
+		defer f.Close()
+		if err := readFromExecFifo(f); err != nil {
+			return err
+		}
+		return os.Remove(path)
 	}
-	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+}
+
+func readFromExecFifo(execFifo io.Reader) error {
+	data, err := ioutil.ReadAll(execFifo)
 	if err != nil {
 		return err
 	}
-	if len(data) > 0 {
-		os.Remove(path)
-		return nil
+	if len(data) <= 0 {
+		return fmt.Errorf("cannot start an already running container")
 	}
-	return fmt.Errorf("cannot start an already running container")
+	return nil
+}
+
+func awaitProcessExit(pid int, exit <-chan struct{}) <-chan struct{} {
+	isDead := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-exit:
+				return
+			case <-time.After(time.Millisecond * 100):
+				stat, err := system.Stat(pid)
+				if err != nil || stat.State == system.Zombie {
+					close(isDead)
+					return
+				}
+			}
+		}
+	}()
+	return isDead
+}
+
+func awaitFifoOpen(path string) <-chan openResult {
+	fifoOpened := make(chan openResult)
+	go func() {
+		f, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			fifoOpened <- openResult{err: newSystemErrorWithCause(err, "open exec fifo for reading")}
+			return
+		}
+		fifoOpened <- openResult{file: f}
+	}()
+	return fifoOpened
+}
+
+type openResult struct {
+	file *os.File
+	err  error
 }
 
 func (c *linuxContainer) start(process *Process, isInit bool) error {
@@ -308,11 +360,13 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 		c.initProcessStartTime = state.InitProcessStartTime
 
 		if c.config.Hooks != nil {
+			bundle, annotations := utils.Annotations(c.config.Labels)
 			s := configs.HookState{
-				Version: c.config.Version,
-				ID:      c.id,
-				Pid:     parent.pid(),
-				Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+				Version:     c.config.Version,
+				ID:          c.id,
+				Pid:         parent.pid(),
+				Bundle:      bundle,
+				Annotations: annotations,
 			}
 			for i, hook := range c.config.Hooks.Poststart {
 				if err := hook.Run(s); err != nil {
@@ -322,10 +376,6 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 					return newSystemErrorWithCausef(err, "running poststart hook %d", i)
 				}
 			}
-		}
-	} else {
-		c.state = &runningState{
-			c: c,
 		}
 	}
 	return nil
@@ -1436,11 +1486,13 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 		}
 	case notify.GetScript() == "setup-namespaces":
 		if c.config.Hooks != nil {
+			bundle, annotations := utils.Annotations(c.config.Labels)
 			s := configs.HookState{
-				Version: c.config.Version,
-				ID:      c.id,
-				Pid:     int(notify.GetPid()),
-				Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+				Version:     c.config.Version,
+				ID:          c.id,
+				Pid:         int(notify.GetPid()),
+				Bundle:      bundle,
+				Annotations: annotations,
 			}
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {
@@ -1748,7 +1800,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 			// The following only applies if we are root.
 			if !c.config.Rootless {
 				// check if we have CAP_SETGID to setgroup properly
-				pid, err := capability.NewPid(os.Getpid())
+				pid, err := capability.NewPid(0)
 				if err != nil {
 					return nil, err
 				}

--- a/vendor/github.com/opencontainers/runc/libcontainer/process_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/process_linux.go
@@ -341,11 +341,13 @@ func (p *initProcess) start() error {
 				}
 
 				if p.config.Config.Hooks != nil {
+					bundle, annotations := utils.Annotations(p.container.config.Labels)
 					s := configs.HookState{
-						Version: p.container.config.Version,
-						ID:      p.container.id,
-						Pid:     p.pid(),
-						Bundle:  utils.SearchLabels(p.config.Config.Labels, "bundle"),
+						Version:     p.container.config.Version,
+						ID:          p.container.id,
+						Pid:         p.pid(),
+						Bundle:      bundle,
+						Annotations: annotations,
 					}
 					for i, hook := range p.config.Config.Hooks.Prestart {
 						if err := hook.Run(s); err != nil {
@@ -370,11 +372,13 @@ func (p *initProcess) start() error {
 				}
 			}
 			if p.config.Config.Hooks != nil {
+				bundle, annotations := utils.Annotations(p.container.config.Labels)
 				s := configs.HookState{
-					Version: p.container.config.Version,
-					ID:      p.container.id,
-					Pid:     p.pid(),
-					Bundle:  utils.SearchLabels(p.config.Config.Labels, "bundle"),
+					Version:     p.container.config.Version,
+					ID:          p.container.id,
+					Pid:         p.pid(),
+					Bundle:      bundle,
+					Annotations: annotations,
 				}
 				for i, hook := range p.config.Config.Hooks.Prestart {
 					if err := hook.Run(s); err != nil {

--- a/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
@@ -100,8 +100,10 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 
 	if config.NoPivotRoot {
 		err = msMoveRoot(config.Rootfs)
-	} else {
+	} else if config.Namespaces.Contains(configs.NEWNS) {
 		err = pivotRoot(config.Rootfs)
+	} else {
+		err = chroot(config.Rootfs)
 	}
 	if err != nil {
 		return newSystemErrorWithCause(err, "jailing process inside rootfs")
@@ -702,6 +704,10 @@ func msMoveRoot(rootfs string) error {
 	if err := unix.Mount(rootfs, "/", "", unix.MS_MOVE, ""); err != nil {
 		return err
 	}
+	return chroot(rootfs)
+}
+
+func chroot(rootfs string) error {
 	if err := unix.Chroot("."); err != nil {
 		return err
 	}
@@ -772,10 +778,10 @@ func remountReadonly(m *configs.Mount) error {
 // mounts ( proc/kcore ).
 // For files, maskPath bind mounts /dev/null over the top of the specified path.
 // For directories, maskPath mounts read-only tmpfs over the top of the specified path.
-func maskPath(path string) error {
+func maskPath(path string, mountLabel string) error {
 	if err := unix.Mount("/dev/null", path, "", unix.MS_BIND, ""); err != nil && !os.IsNotExist(err) {
 		if err == unix.ENOTDIR {
-			return unix.Mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, "")
+			return unix.Mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("", mountLabel))
 		}
 		return err
 	}

--- a/vendor/github.com/opencontainers/runc/libcontainer/specconv/example.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/specconv/example.go
@@ -155,9 +155,9 @@ func Example() *specs.Spec {
 	}
 }
 
-// ExampleRootless returns an example spec file that works with rootless
-// containers. It's essentially a modified version of the specfile from
-// Example().
+// ToRootless converts the given spec file into one that should work with
+// rootless containers, by removing incompatible options and adding others that
+// are needed.
 func ToRootless(spec *specs.Spec) {
 	var namespaces []specs.LinuxNamespace
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go
@@ -192,9 +192,6 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 	if err := createDevices(spec, config); err != nil {
 		return nil, err
 	}
-	if err := setupUserNamespace(spec, config); err != nil {
-		return nil, err
-	}
 	c, err := createCgroupConfig(opts)
 	if err != nil {
 		return nil, err
@@ -224,6 +221,11 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				{
 					Type: "loopback",
 				},
+			}
+		}
+		if config.Namespaces.Contains(configs.NEWUSER) {
+			if err := setupUserNamespace(spec, config); err != nil {
+				return nil, err
 			}
 		}
 		config.MaskPaths = spec.Linux.MaskedPaths

--- a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
@@ -65,14 +65,9 @@ func (l *linuxStandardInit) Init() error {
 	}
 
 	label.Init()
-
-	// prepareRootfs() can be executed only for a new mount namespace.
-	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := prepareRootfs(l.pipe, l.config); err != nil {
-			return err
-		}
+	if err := prepareRootfs(l.pipe, l.config); err != nil {
+		return err
 	}
-
 	// Set up the console. This has to be done *before* we finalize the rootfs,
 	// but *after* we've given the user the chance to set up all of the mounts
 	// they wanted.
@@ -115,7 +110,7 @@ func (l *linuxStandardInit) Init() error {
 		}
 	}
 	for _, path := range l.config.Config.MaskPaths {
-		if err := maskPath(path); err != nil {
+		if err := maskPath(path, l.config.Config.MountLabel); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
@@ -63,10 +63,12 @@ func destroy(c *linuxContainer) error {
 
 func runPoststopHooks(c *linuxContainer) error {
 	if c.config.Hooks != nil {
+		bundle, annotations := utils.Annotations(c.config.Labels)
 		s := configs.HookState{
-			Version: c.config.Version,
-			ID:      c.id,
-			Bundle:  utils.SearchLabels(c.config.Labels, "bundle"),
+			Version:     c.config.Version,
+			ID:          c.id,
+			Bundle:      bundle,
+			Annotations: annotations,
 		}
 		for _, hook := range c.config.Hooks.Poststop {
 			if err := hook.Run(s); err != nil {

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup.go
@@ -12,84 +12,30 @@ var (
 	ErrNoGroupEntries  = errors.New("no matching entries in group file")
 )
 
-func lookupUser(filter func(u User) bool) (User, error) {
-	// Get operating system-specific passwd reader-closer.
-	passwd, err := GetPasswd()
-	if err != nil {
-		return User{}, err
-	}
-	defer passwd.Close()
-
-	// Get the users.
-	users, err := ParsePasswdFilter(passwd, filter)
-	if err != nil {
-		return User{}, err
-	}
-
-	// No user entries found.
-	if len(users) == 0 {
-		return User{}, ErrNoPasswdEntries
-	}
-
-	// Assume the first entry is the "correct" one.
-	return users[0], nil
-}
-
 // LookupUser looks up a user by their username in /etc/passwd. If the user
 // cannot be found (or there is no /etc/passwd file on the filesystem), then
 // LookupUser returns an error.
 func LookupUser(username string) (User, error) {
-	return lookupUser(func(u User) bool {
-		return u.Name == username
-	})
+	return lookupUser(username)
 }
 
 // LookupUid looks up a user by their user id in /etc/passwd. If the user cannot
 // be found (or there is no /etc/passwd file on the filesystem), then LookupId
 // returns an error.
 func LookupUid(uid int) (User, error) {
-	return lookupUser(func(u User) bool {
-		return u.Uid == uid
-	})
-}
-
-func lookupGroup(filter func(g Group) bool) (Group, error) {
-	// Get operating system-specific group reader-closer.
-	group, err := GetGroup()
-	if err != nil {
-		return Group{}, err
-	}
-	defer group.Close()
-
-	// Get the users.
-	groups, err := ParseGroupFilter(group, filter)
-	if err != nil {
-		return Group{}, err
-	}
-
-	// No user entries found.
-	if len(groups) == 0 {
-		return Group{}, ErrNoGroupEntries
-	}
-
-	// Assume the first entry is the "correct" one.
-	return groups[0], nil
+	return lookupUid(uid)
 }
 
 // LookupGroup looks up a group by its name in /etc/group. If the group cannot
 // be found (or there is no /etc/group file on the filesystem), then LookupGroup
 // returns an error.
 func LookupGroup(groupname string) (Group, error) {
-	return lookupGroup(func(g Group) bool {
-		return g.Name == groupname
-	})
+	return lookupGroup(groupname)
 }
 
 // LookupGid looks up a group by its group id in /etc/group. If the group cannot
 // be found (or there is no /etc/group file on the filesystem), then LookupGid
 // returns an error.
 func LookupGid(gid int) (Group, error) {
-	return lookupGroup(func(g Group) bool {
-		return g.Gid == gid
-	})
+	return lookupGid(gid)
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
@@ -15,6 +15,76 @@ const (
 	unixGroupPath  = "/etc/group"
 )
 
+func lookupUser(username string) (User, error) {
+	return lookupUserFunc(func(u User) bool {
+		return u.Name == username
+	})
+}
+
+func lookupUid(uid int) (User, error) {
+	return lookupUserFunc(func(u User) bool {
+		return u.Uid == uid
+	})
+}
+
+func lookupUserFunc(filter func(u User) bool) (User, error) {
+	// Get operating system-specific passwd reader-closer.
+	passwd, err := GetPasswd()
+	if err != nil {
+		return User{}, err
+	}
+	defer passwd.Close()
+
+	// Get the users.
+	users, err := ParsePasswdFilter(passwd, filter)
+	if err != nil {
+		return User{}, err
+	}
+
+	// No user entries found.
+	if len(users) == 0 {
+		return User{}, ErrNoPasswdEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return users[0], nil
+}
+
+func lookupGroup(groupname string) (Group, error) {
+	return lookupGroupFunc(func(g Group) bool {
+		return g.Name == groupname
+	})
+}
+
+func lookupGid(gid int) (Group, error) {
+	return lookupGroupFunc(func(g Group) bool {
+		return g.Gid == gid
+	})
+}
+
+func lookupGroupFunc(filter func(g Group) bool) (Group, error) {
+	// Get operating system-specific group reader-closer.
+	group, err := GetGroup()
+	if err != nil {
+		return Group{}, err
+	}
+	defer group.Close()
+
+	// Get the users.
+	groups, err := ParseGroupFilter(group, filter)
+	if err != nil {
+		return Group{}, err
+	}
+
+	// No user entries found.
+	if len(groups) == 0 {
+		return Group{}, ErrNoGroupEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return groups[0], nil
+}
+
 func GetPasswdPath() (string, error) {
 	return unixPasswdPath, nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_windows.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_windows.go
@@ -1,0 +1,40 @@
+// +build windows
+
+package user
+
+import (
+	"fmt"
+	"os/user"
+)
+
+func lookupUser(username string) (User, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return User{}, err
+	}
+	return userFromOS(u)
+}
+
+func lookupUid(uid int) (User, error) {
+	u, err := user.LookupId(fmt.Sprintf("%d", uid))
+	if err != nil {
+		return User{}, err
+	}
+	return userFromOS(u)
+}
+
+func lookupGroup(groupname string) (Group, error) {
+	g, err := user.LookupGroup(groupname)
+	if err != nil {
+		return Group{}, err
+	}
+	return groupFromOS(g)
+}
+
+func lookupGid(gid int) (Group, error) {
+	g, err := user.LookupGroupId(fmt.Sprintf("%d", gid))
+	if err != nil {
+		return Group{}, err
+	}
+	return groupFromOS(g)
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"strconv"
 	"strings"
 )
@@ -28,11 +29,50 @@ type User struct {
 	Shell string
 }
 
+// userFromOS converts an os/user.(*User) to local User
+//
+// (This does not include Pass, Shell or Gecos)
+func userFromOS(u *user.User) (User, error) {
+	newUser := User{
+		Name: u.Username,
+		Home: u.HomeDir,
+	}
+	id, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return newUser, err
+	}
+	newUser.Uid = id
+
+	id, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		return newUser, err
+	}
+	newUser.Gid = id
+	return newUser, nil
+}
+
 type Group struct {
 	Name string
 	Pass string
 	Gid  int
 	List []string
+}
+
+// groupFromOS converts an os/user.(*Group) to local Group
+//
+// (This does not include Pass, Shell or Gecos)
+func groupFromOS(g *user.Group) (Group, error) {
+	newGroup := Group{
+		Name: g.Name,
+	}
+
+	id, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return newGroup, err
+	}
+	newGroup.Gid = id
+
+	return newGroup, nil
 }
 
 func parseLine(line string, v ...interface{}) {


### PR DESCRIPTION
Main reason for updating this vendoring is to include the recent
patch solving the container state issue when exec'ing a process
on a container not yet running.

Shortlog:

985628d libcontainer: Don't set container state to running when exec'ing
58415b4 Fix error message
4f4af7b rootless: set sticky bit if using XDG_RUNTIME_DIR
74e961e tests: allow to load kernel modules from a test container
43aea05 Label the masked tmpfs with the mount label
04e95b5 Add timeout while waiting for StartTransinetUnit completion signal from dbus
3d26fc3 cgroups/fs: fix NPE on Destroy than no cgroups are set
e7e303a Minor wording enhancement in readme
bf74951 libcontainer/user: platform dependent calls
8d7b573 makefile: make "release" PHONY
10a4cde Fix make shell
442a6cf VERSION: back to development
4fc53a8 VERSION: bump to v1.0.0-rc5
2420eb1 The setupUserNamespace function is always called.
8be3162 upgrade criu to v3.7
121c7b4 upgrade to go 1.10 with debian stretch
3f32e72 fix lint error in specconv
0f3d824 adding go get instruction to readme
59e5b61 Update console dependency to fix runc exec on BE
50dc7ee libcontainer/capabilities_linux: Drop os.Getpid() call
7019e1d fix systemd slice expansion so that it could be consumed by cAdvisor
72f92cf Warning message if 'go-md2man' is not yet installed
7ac503d kill.go: Remove unnecessary checks
be16b13 libcontainer/state_linux_test: Add a testTransitions helper
91ca331 chroot when no mount namespaces is provided
dd5eb3b make: validate C format
5c0af14 Return from goroutine when it should terminate
8d3e6c9 Avoid race when opening exec fifo
862e491 man: Fix manpages related to console
cd1e7ab libcontainer: expose annotations in hooks
d5b4a3e Fix race against systemd
a1edc03 Pin version of gojsonschema in tests

Fixes #202

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>