### PR TITLE
agent: add server interceptor to log grpc requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,8 +55,11 @@ func (c *agentConfig) getConfig(cmdLineFile string) error {
 	return nil
 }
 
-func (c *agentConfig) applyConfig() {
+func (c *agentConfig) applyConfig(s *sandbox) {
 	agentLog.Logger.SetLevel(c.logLevel)
+	if c.logLevel == logrus.DebugLevel {
+		s.enableGrpcTrace = true
+	}
 }
 
 //Parse a string that represents a kernel cmdline option

--- a/config_test.go
+++ b/config_test.go
@@ -140,3 +140,27 @@ func TestGetConfig(t *testing.T) {
 		"Log levels should be identical: got %+v, expecting %+v",
 		a.logLevel, logrus.InfoLevel)
 }
+
+func TestSetGrpcTrace(t *testing.T) {
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.NoError(err, "%v", err)
+	fileName := tmpFile.Name()
+
+	tmpFile.Write([]byte(logLevelFlag + "=debug"))
+	tmpFile.Close()
+
+	defer os.Remove(fileName)
+
+	err = a.getConfig(fileName)
+	assert.NoError(err, "%v", err)
+
+	s := &sandbox{}
+
+	a.applyConfig(s)
+
+	assert.True(s.enableGrpcTrace, "grpc trace should be enabled")
+}


### PR DESCRIPTION
When agent_log is set to `debug` level, trace all grpc requests and
responses.

Fixes: #183