### PR TITLE
uevent: Fix netlink error while assigning pid in netlink client

### DIFF
--- a/pkg/uevent/uevent.go
+++ b/pkg/uevent/uevent.go
@@ -9,7 +9,6 @@ package uevent
 import (
 	"bufio"
 	"io"
-	"os"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -35,7 +34,9 @@ type ReaderCloser struct {
 func NewReaderCloser() (io.ReadCloser, error) {
 	nl := unix.SockaddrNetlink{
 		Family: unix.AF_NETLINK,
-		Pid:    uint32(os.Getpid()),
+		// Passing Pid as 0 here allows the kernel to take care of assigning
+		// it. This allows multiple netlink sockets to be used.
+		Pid:    uint32(0),
 		Groups: 1,
 	}
 


### PR DESCRIPTION
unix.SockaddrNetlink represents a netlink client with the Pid
being the netlink socket address. This can be assigned the actual
pid of the process, but in case we have two netlink sockets opened
at the same time, this results in errors in binding to the netlink
socket. Assign this to zero which means the kernel takes care of
assigning it.

See http://man7.org/linux/man-pages/man7/netlink.7.html

Fixes #216

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>