### PR TITLE
grpc: update cpuset cgroup

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -71,6 +71,15 @@ const onlineCPUMemWaitTime = 100 * time.Millisecond
 
 const onlineCPUMaxTries = 10
 
+// handleError will log the specified error if wait is false
+func handleError(wait bool, err error) error {
+	if !wait {
+		agentLog.WithError(err).Error()
+	}
+
+	return err
+}
+
 // Online resources, nbResources specifies the maximum number of resources to online.
 // If nbResources is <= 0 then there is no limit and all resources are connected.
 // Returns the number of resources connected.

--- a/grpc.go
+++ b/grpc.go
@@ -54,8 +54,10 @@ const (
 )
 
 var (
-	sysfsCPUOnlinePath = "/sys/devices/system/cpu"
-	sysfsMemOnlinePath = "/sys/devices/system/memory"
+	sysfsCPUOnlinePath     = "/sys/devices/system/cpu"
+	sysfsMemOnlinePath     = "/sys/devices/system/memory"
+	sysfsConnectedCPUsPath = filepath.Join(sysfsCPUOnlinePath, "online")
+	sysfsDockerCpusetPath  = "/sys/fs/cgroup/cpuset/docker/cpuset.cpus"
 )
 
 type onlineResource struct {
@@ -79,6 +81,8 @@ func handleError(wait bool, err error) error {
 
 	return err
 }
+
+const dockerCpusetMode = 0644
 
 // Online resources, nbResources specifies the maximum number of resources to online.
 // If nbResources is <= 0 then there is no limit and all resources are connected.
@@ -154,19 +158,55 @@ func onlineMemResources() error {
 	return err
 }
 
-func onlineCPUMem(req *pb.OnlineCPUMemRequest) error {
+func (a *agentGRPC) onlineCPUMem(req *pb.OnlineCPUMemRequest) error {
 	if req.NbCpus <= 0 {
-		return fmt.Errorf("requested number of CPUs '%d' must be greater than 0", req.NbCpus)
+		return handleError(req.Wait, fmt.Errorf("requested number of CPUs '%d' must be greater than 0", req.NbCpus))
 	}
 
 	onlineCPUMemLock.Lock()
 	defer onlineCPUMemLock.Unlock()
 
 	if err := onlineCPUResources(req.NbCpus); err != nil {
-		return err
+		return handleError(req.Wait, err)
 	}
 
-	return onlineMemResources()
+	if err := onlineMemResources(); err != nil {
+		return handleError(req.Wait, err)
+	}
+
+	// At this point all CPUs have been connected, we need to know
+	// the actual range of CPUs
+	cpus, err := ioutil.ReadFile(sysfsConnectedCPUsPath)
+	if err != nil {
+		return handleError(req.Wait, fmt.Errorf("Could not get the actual range of connected CPUs: %v", err))
+	}
+	connectedCpus := strings.Trim(string(cpus), "\t\n ")
+
+	// In order to update container's cpuset cgroups, docker's cpuset cgroup MUST BE updated with
+	// the actual number of connected CPUs
+	if err := ioutil.WriteFile(sysfsDockerCpusetPath, []byte(connectedCpus), dockerCpusetMode); err != nil {
+		return handleError(req.Wait, fmt.Errorf("Could not update docker cpuset cgroup '%s': %v", connectedCpus, err))
+	}
+
+	// Now that we know the actual range of connected CPUs, we need to iterate over
+	// all containers an update each cpuset cgroup. This is not required in docker
+	// containers since they don't hot add/remove CPUs.
+	for _, c := range a.sandbox.containers {
+		contConfig := c.container.Config()
+		// Don't update cpuset cgroup if one was already defined.
+		if contConfig.Cgroups.Resources.CpusetCpus != "" {
+			continue
+		}
+		contConfig.Cgroups.Resources = &configs.Resources{
+			CpusetCpus: connectedCpus,
+		}
+		if err := c.container.Set(contConfig); err != nil {
+			return handleError(req.Wait, err)
+		}
+
+	}
+
+	return nil
 }
 
 func setConsoleCarriageReturn(fd int) error {
@@ -945,9 +985,9 @@ func (a *agentGRPC) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesReques
 
 func (a *agentGRPC) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*gpb.Empty, error) {
 	if !req.Wait {
-		go onlineCPUMem(req)
+		go a.onlineCPUMem(req)
 		return emptyResp, nil
 	}
 
-	return emptyResp, onlineCPUMem(req)
+	return emptyResp, a.onlineCPUMem(req)
 }

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -110,7 +110,11 @@ func TestUpdateContainerConfigPrivilegesNoNewPrivileges(t *testing.T) {
 
 func TestOnlineCPUMem(t *testing.T) {
 	assert := assert.New(t)
-	a := &agentGRPC{}
+	a := &agentGRPC{
+		sandbox: &sandbox{
+			containers: make(map[string]*container),
+		},
+	}
 
 	req := &pb.OnlineCPUMemRequest{
 		NbCpus: 1,
@@ -125,6 +129,7 @@ func TestOnlineCPUMem(t *testing.T) {
 	sysfsCPUOnlinePath, err = ioutil.TempDir("", "cpu")
 	assert.NoError(err)
 	defer os.RemoveAll(sysfsCPUOnlinePath)
+	sysfsConnectedCPUsPath = filepath.Join(sysfsCPUOnlinePath, "online")
 
 	sysfsMemOnlinePath, err = ioutil.TempDir("", "memory")
 	assert.NoError(err)
@@ -144,12 +149,30 @@ func TestOnlineCPUMem(t *testing.T) {
 	err = ioutil.WriteFile(cpu0Online, []byte("0"), 0755)
 	assert.NoError(err)
 
-	memory0dir := filepath.Join(sysfsCPUOnlinePath, "memory0")
+	memory0dir := filepath.Join(sysfsMemOnlinePath, "memory0")
 	err = os.Mkdir(memory0dir, 0775)
 	assert.NoError(err)
 
 	memory0Online := filepath.Join(memory0dir, "online")
 	err = ioutil.WriteFile(memory0Online, []byte("0"), 0755)
+	assert.NoError(err)
+
+	_, err = a.OnlineCPUMem(context.TODO(), req)
+	assert.Error(err, "connected cpus path does not exist")
+	sysfsConnectedCPUsPath = filepath.Join(sysfsCPUOnlinePath, "online")
+	ioutil.WriteFile(sysfsConnectedCPUsPath, []byte("0-4"), 0644)
+
+	_, err = a.OnlineCPUMem(context.TODO(), req)
+	assert.Error(err, "docker cgroup path does not exist")
+
+	dockerCpusetPath, err := ioutil.TempDir("", "docker")
+	assert.NoError(err)
+	defer os.RemoveAll(dockerCpusetPath)
+	sysfsDockerCpusetPath = filepath.Join(dockerCpusetPath, "cpuset.cpus")
+
+	err = ioutil.WriteFile(memory0Online, []byte("0"), 0755)
+	assert.NoError(err)
+	err = ioutil.WriteFile(cpu0Online, []byte("0"), 0755)
 	assert.NoError(err)
 
 	_, err = a.OnlineCPUMem(context.TODO(), req)


### PR DESCRIPTION
Each time a container is created, it is placed inside a cpuset cgroup
with the actual number of vCPUs, when more vCPUs are hot added this cgroup
MUST BE updated to allow containers accessing to these new resources. The
cpuset cgroup is not updated if the container already have one defined by user.

fixes #219

Signed-off-by: Julio Montes <julio.montes@intel.com>