### PR TITLE
rework signal handling code and backtrace on SIGUSR1

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -703,17 +703,20 @@ func main() {
 	}
 
 	if err = s.initLogger(); err != nil {
+		agentLog.WithError(err).Error("failed to setup logger")
 		return
 	}
 
 	// Set agent as subreaper.
 	if err = s.setSubreaper(); err != nil {
+		agentLog.WithError(err).Error("failed to setup signal handler")
 		return
 	}
 
 	// Check for vsock vs serial. This will fill the sandbox structure with
 	// information about the channel.
 	if err = s.initChannel(); err != nil {
+		agentLog.WithError(err).Error("failed to setup channels")
 		return
 	}
 

--- a/agent.go
+++ b/agent.go
@@ -387,7 +387,7 @@ func (s *sandbox) setSubreaper() error {
 }
 
 // getMemory returns a string containing the total amount of memory reported
-// by the kernell. The string includes a suffix denoting the units the memory
+// by the kernel. The string includes a suffix denoting the units the memory
 // is measured in.
 func getMemory() (string, error) {
 	bytes, err := ioutil.ReadFile(meminfo)

--- a/agent.go
+++ b/agent.go
@@ -97,6 +97,8 @@ var agentLog = logrus.WithFields(agentFields)
 // version is the agent version. This variable is populated at build time.
 var version = "unknown"
 
+var debug = false
+
 // if true, coredump when an internal error occurs or a fatal signal is received
 var crashOnError = false
 
@@ -383,6 +385,12 @@ func (s *sandbox) signalHandlerLoop(sigCh chan os.Signal) {
 		if fatalSignal(nativeSignal) {
 			logger.Error("received fatal signal")
 			die()
+		}
+
+		if debug && nonFatalSignal(nativeSignal) {
+			logger.Debug("handling signal")
+			backtrace()
+			continue
 		}
 
 		logger.Info("ignoring unexpected signal")

--- a/agent.go
+++ b/agent.go
@@ -361,14 +361,16 @@ func (s *sandbox) listenToUdevEvents() {
 // This loop is meant to be run inside a separate Go routine.
 func (s *sandbox) signalHandlerLoop(sigCh chan os.Signal) {
 	for sig := range sigCh {
+		logger := agentLog.WithField("signal", sig)
+
 		switch sig {
 		case unix.SIGCHLD:
 			if err := s.subreaper.reap(); err != nil {
-				agentLog.Error(err)
+				logger.WithError(err).Error("failed to reap")
 				return
 			}
 		default:
-			agentLog.Infof("Unexpected signal %s, nothing to do...", sig.String())
+			logger.Info("ignoring unexpected signal")
 		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -71,6 +71,13 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 		optionSeparator = "="
 	)
 
+	if option == devModeFlag {
+		crashOnError = true
+		debug = true
+
+		return nil
+	}
+
 	split := strings.Split(option, optionSeparator)
 
 	if len(split) < valuePosition+1 {
@@ -84,8 +91,9 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 			return err
 		}
 		c.logLevel = level
-	case devModeFlag:
-		crashOnError = true
+		if level == logrus.DebugLevel {
+			debug = true
+		}
 	default:
 		if strings.HasPrefix(split[optionPosition], optionPrefix) {
 			return grpcStatus.Errorf(codes.NotFound, "Unknown option %s", split[optionPosition])

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ import (
 const (
 	optionPrefix      = "agent."
 	logLevelFlag      = optionPrefix + "log"
+	devModeFlag       = optionPrefix + "devmode"
 	kernelCmdlineFile = "/proc/cmdline"
 )
 
@@ -83,6 +84,8 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 			return err
 		}
 		c.logLevel = level
+	case devModeFlag:
+		crashOnError = true
 	default:
 		if strings.HasPrefix(split[optionPosition], optionPrefix) {
 			return grpcStatus.Errorf(codes.NotFound, "Unknown option %s", split[optionPosition])

--- a/config_test.go
+++ b/config_test.go
@@ -71,10 +71,15 @@ func TestParseCmdlineOptionCorrectOptions(t *testing.T) {
 	logFlagList := []string{"debug", "info", "warn", "error", "fatal", "panic"}
 
 	for _, logFlag := range logFlagList {
+		debug = false
 		option := logLevelFlag + "=" + logFlag
 
 		err := a.parseCmdlineOption(option)
 		assert.NoError(err, "%v", err)
+
+		if logFlag == "debug" {
+			assert.True(debug)
+		}
 	}
 }
 
@@ -90,6 +95,45 @@ func TestParseCmdlineOptionIncorrectOptions(t *testing.T) {
 
 		err := a.parseCmdlineOption(option)
 		assert.Errorf(err, "Should fail because of incorrect option %q", logFlag)
+	}
+}
+
+func TestParseCmdlineOptionDevMode(t *testing.T) {
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	type testData struct {
+		option               string
+		expectDevModeEnabled bool
+	}
+
+	data := []testData{
+		{"agent.Devmode", false},
+		{"agent.DevMode", false},
+		{"devmode", false},
+		{"DevMode", false},
+		{"agent.devmodel", false},
+		{"agent.devmode.", false},
+		{"agent.devmode-", false},
+		{"agent.devmode:", false},
+
+		{"agent.devmode", true},
+	}
+
+	for i, d := range data {
+		debug = false
+		crashOnError = false
+
+		err := a.parseCmdlineOption(d.option)
+		assert.NoError(err)
+
+		if !d.expectDevModeEnabled {
+			continue
+		}
+
+		assert.True(debug, "test %d (%+v)", i, d)
+		assert.True(crashOnError, "test %d (%+v)", i, d)
 	}
 }
 

--- a/signals.go
+++ b/signals.go
@@ -27,6 +27,7 @@ var handledSignalsMap = map[syscall.Signal]bool{
 	syscall.SIGSTKFLT: true,
 	syscall.SIGSYS:    true,
 	syscall.SIGTRAP:   true,
+	syscall.SIGUSR1:   false,
 }
 
 func handlePanic() {
@@ -63,6 +64,15 @@ func fatalSignal(sig syscall.Signal) bool {
 	}
 
 	return s
+}
+
+func nonFatalSignal(sig syscall.Signal) bool {
+	s, exists := handledSignalsMap[sig]
+	if !exists {
+		return false
+	}
+
+	return !s
 }
 
 func handledSignals() []syscall.Signal {

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+)
+
+// List of handled signals.
+//
+// The value is true if receiving the signal should be fatal.
+var handledSignalsMap = map[syscall.Signal]bool{
+	syscall.SIGABRT:   true,
+	syscall.SIGBUS:    true,
+	syscall.SIGILL:    true,
+	syscall.SIGQUIT:   true,
+	syscall.SIGSEGV:   true,
+	syscall.SIGSTKFLT: true,
+	syscall.SIGSYS:    true,
+	syscall.SIGTRAP:   true,
+}
+
+func handlePanic() {
+	r := recover()
+
+	if r != nil {
+		msg := fmt.Sprintf("%s", r)
+		agentLog.WithField("panic", msg).Error("fatal error")
+
+		die()
+	}
+}
+
+func backtrace() {
+	profiles := pprof.Profiles()
+
+	buf := &bytes.Buffer{}
+
+	for _, p := range profiles {
+		// The magic number requests a full stacktrace. See
+		// https://golang.org/pkg/runtime/pprof/#Profile.WriteTo.
+		pprof.Lookup(p.Name()).WriteTo(buf, 2)
+	}
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		agentLog.Error(line)
+	}
+}
+
+func fatalSignal(sig syscall.Signal) bool {
+	s, exists := handledSignalsMap[sig]
+	if !exists {
+		return false
+	}
+
+	return s
+}
+
+func handledSignals() []syscall.Signal {
+	var signals []syscall.Signal
+
+	for sig := range handledSignalsMap {
+		signals = append(signals, sig)
+	}
+
+	return signals
+}
+
+func die() {
+	backtrace()
+
+	if crashOnError {
+		signal.Reset(syscall.SIGABRT)
+		syscall.Kill(0, syscall.SIGABRT)
+	}
+
+	os.Exit(1)
+}

--- a/signals_test.go
+++ b/signals_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"reflect"
+	goruntime "runtime"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalHandledSignalsMap(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := fatalSignal(sig)
+		if fatal {
+			assert.True(result)
+		} else {
+			assert.False(result)
+		}
+	}
+}
+
+func TestSignalHandledSignals(t *testing.T) {
+	assert := assert.New(t)
+
+	var expected []syscall.Signal
+
+	for sig := range handledSignalsMap {
+		expected = append(expected, sig)
+	}
+
+	got := handledSignals()
+
+	sort.Slice(expected, func(i, j int) bool {
+		return int(expected[i]) < int(expected[j])
+	})
+
+	sort.Slice(got, func(i, j int) bool {
+		return int(got[i]) < int(got[j])
+	})
+
+	assert.True(reflect.DeepEqual(expected, got))
+}
+
+func TestSignalFatalSignalInvalidSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	sig := syscall.SIGXCPU
+
+	result := fatalSignal(sig)
+	assert.False(result)
+}
+
+func TestSignalBacktrace(t *testing.T) {
+	assert := assert.New(t)
+
+	// create buffer to save logger output
+	buf := &bytes.Buffer{}
+
+	savedLog := agentLog
+	defer func() {
+		agentLog = savedLog
+	}()
+
+	agentLog = logrus.WithField("test-agent-logger", true)
+
+	agentLog.Logger.Formatter = &logrus.TextFormatter{
+		DisableColors: true,
+	}
+
+	// capture output to buffer
+	agentLog.Logger.Out = buf
+
+	// determine name of *this* function
+	pc := make([]uintptr, 1)
+	goruntime.Callers(1, pc)
+	fn := goruntime.FuncForPC(pc[0])
+	name := fn.Name()
+
+	backtrace()
+
+	b := buf.String()
+
+	// very basic tests to check if a backtrace was produced
+	assert.True(strings.Contains(b, "contention:"))
+	assert.True(strings.Contains(b, `level=error`))
+	assert.True(strings.Contains(b, name))
+}

--- a/signals_test.go
+++ b/signals_test.go
@@ -18,6 +18,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSignalFatalSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := nonFatalSignal(sig)
+		if fatal {
+			assert.False(result)
+		} else {
+			assert.True(result)
+		}
+	}
+}
+
 func TestSignalHandledSignalsMap(t *testing.T) {
 	assert := assert.New(t)
 
@@ -53,12 +66,34 @@ func TestSignalHandledSignals(t *testing.T) {
 	assert.True(reflect.DeepEqual(expected, got))
 }
 
+func TestSignalNonFatalSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	for sig, fatal := range handledSignalsMap {
+		result := nonFatalSignal(sig)
+		if fatal {
+			assert.False(result)
+		} else {
+			assert.True(result)
+		}
+	}
+}
+
 func TestSignalFatalSignalInvalidSignal(t *testing.T) {
 	assert := assert.New(t)
 
 	sig := syscall.SIGXCPU
 
 	result := fatalSignal(sig)
+	assert.False(result)
+}
+
+func TestSignalNonFatalSignalInvalidSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	sig := syscall.SIGXCPU
+
+	result := nonFatalSignal(sig)
 	assert.False(result)
 }
 


### PR DESCRIPTION
signal: Switch to standard signal handling     

Change from using the golang "debug" package for providing backtraces to                       
using the Kata Project standard signal handling code:                                          

- A trace is written to the agents logger if a fatal signal is received                        
or an internal error is detected.              

- For consistency with other components, it is possible to enable a                            
coredump on fatal error. However, this is not desirable even with debug                        
enabled so the agent will only attempt to dump core if the new developer                       
mode (enabled by specifying `agent.devmode` on the guest kernel                                
command-line) is enabled.                      

---

signal: Backtrace on SIGUSR1                   

Rework the signal handling code so that if debug is enabled and a                              
`SIGUSR1` signal is received, backtrace to the system log but continue                         
to run.                                        

Note that developer mode will also automatically enable this behaviour.                        

Added some basic tests for the signal handling code. 

Fixes #218. 

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>  