### PR TITLE
agent: Simplify tearing down the network

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -853,6 +853,7 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 
 	a.sandbox.id = req.Hostname
 	a.sandbox.containers = make(map[string]*container)
+	a.sandbox.network.ifaces = make(map[string]*pb.Interface)
 	a.sandbox.network.dns = req.Dns
 	a.sandbox.running = true
 

--- a/network.go
+++ b/network.go
@@ -25,10 +25,10 @@ import (
 // related information.
 type network struct {
 	ifacesLock sync.Mutex
-	ifaces     []*pb.Interface
+	ifaces     map[string]*pb.Interface
 
 	routesLock sync.Mutex
-	routes     []*pb.Route
+	routes     []pb.Route
 
 	dns []string
 }
@@ -139,7 +139,7 @@ func (s *sandbox) addInterface(netHandle *netlink.Handle, iface *pb.Interface) (
 	}
 
 	// Update sandbox interface list.
-	s.network.ifaces = append(s.network.ifaces, iface)
+	s.network.ifaces[iface.Name] = iface
 
 	return iface, nil
 }
@@ -172,12 +172,7 @@ func (s *sandbox) removeInterface(netHandle *netlink.Handle, iface *pb.Interface
 	}
 
 	// Update sandbox interface list.
-	for idx, sIface := range s.network.ifaces {
-		if sIface.Name == iface.Name {
-			s.network.ifaces = append(s.network.ifaces[:idx], s.network.ifaces[idx+1:]...)
-			break
-		}
-	}
+	delete(s.network.ifaces, iface.Name)
 
 	return nil, nil
 }
@@ -465,7 +460,7 @@ func (s *sandbox) updateRoute(netHandle *netlink.Handle, route *pb.Route, add bo
 		}
 
 		// Add route to sandbox route list.
-		s.network.routes = append(s.network.routes, route)
+		s.network.routes = append(s.network.routes, *route)
 	} else {
 		if err := netHandle.RouteDel(netRoute); err != nil {
 			return grpcStatus.Errorf(codes.Internal, "Could not remove route dest(%s)/gw(%s)/dev(%s): %v",
@@ -508,8 +503,9 @@ func (s *sandbox) removeNetwork() error {
 	}
 	defer netHandle.Delete()
 
-	for _, route := range s.network.routes {
-		if err := s.removeRoute(netHandle, route); err != nil {
+	routeList := s.network.routes
+	for _, route := range routeList {
+		if err := s.removeRoute(netHandle, &route); err != nil {
 			return grpcStatus.Errorf(codes.Internal, "Could not remove network route %v: %v",
 				route, err)
 		}

--- a/network.go
+++ b/network.go
@@ -404,10 +404,6 @@ func getCurrentRoutes(netHandle *netlink.Handle) (*pb.Routes, error) {
 	return &routes, nil
 }
 
-func (s *sandbox) removeRoute(netHandle *netlink.Handle, route *pb.Route) error {
-	return s.updateRoute(netHandle, route, false)
-}
-
 func (s *sandbox) updateRoute(netHandle *netlink.Handle, route *pb.Route, add bool) (err error) {
 	s.network.routesLock.Lock()
 	defer s.network.routesLock.Unlock()
@@ -487,10 +483,6 @@ func setupDNS(dns []string) error {
 	return nil
 }
 
-func removeDNS(dns []string) error {
-	return nil
-}
-
 ////////////
 // Global //
 ////////////
@@ -503,23 +495,11 @@ func (s *sandbox) removeNetwork() error {
 	}
 	defer netHandle.Delete()
 
-	routeList := s.network.routes
-	for _, route := range routeList {
-		if err := s.removeRoute(netHandle, &route); err != nil {
-			return grpcStatus.Errorf(codes.Internal, "Could not remove network route %v: %v",
-				route, err)
-		}
-	}
-
 	for _, iface := range s.network.ifaces {
 		if _, err := s.removeInterface(netHandle, iface); err != nil {
 			return grpcStatus.Errorf(codes.Internal, "Could not remove network interface %v: %v",
 				iface, err)
 		}
-	}
-
-	if err := removeDNS(s.network.dns); err != nil {
-		return grpcStatus.Errorf(codes.Internal, "Could not remove network DNS: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR addresses the issues related to the way the agent currently tears down the network.
First it fixes an issue due to a modification of a list containing pointers instead of copies, while at the same time, this list is being parsed.

Then, with the idea of simplifying the way the network is removed, it introduces a commit removing the network removal code that was called when the sandbox was destroyed. Indeed, such a case means the VM is going to be shut down, leading to the removal of the network by the VM anyway.

Fixes #226
Fixes #230

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>