### PR TITLE
Use PCI Addresses to determine the device names for virtio-blk devices

### DIFF
--- a/device.go
+++ b/device.go
@@ -29,6 +29,8 @@ const (
 	driverSCSIType = "scsi"
 )
 
+const rootBusPath = "/devices/pci0000:00"
+
 // SCSI variables
 var (
 	// Here in "0:0", the first number is the SCSI host number because

--- a/grpc.go
+++ b/grpc.go
@@ -428,7 +428,7 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 	// updates the devices listed in the OCI spec, so that they actually
 	// match real devices inside the VM. This step is necessary since we
 	// cannot predict everything from the caller.
-	if err = addDevices(req.Devices, req.OCI); err != nil {
+	if err = addDevices(req.Devices, req.OCI, a.sandbox); err != nil {
 		return emptyResp, err
 	}
 

--- a/grpc.go
+++ b/grpc.go
@@ -439,7 +439,7 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 	// After all those storages have been processed, no matter the order
 	// here, the agent will rely on libcontainer (using the oci.Mounts
 	// list) to bind mount all of them inside the container.
-	mountList, err := addStorages(req.Storages)
+	mountList, err := addStorages(req.Storages, a.sandbox)
 	if err != nil {
 		return emptyResp, err
 	}
@@ -862,7 +862,7 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 		}
 	}
 
-	mountList, err := addStorages(req.Storages)
+	mountList, err := addStorages(req.Storages, a.sandbox)
 	if err != nil {
 		return emptyResp, err
 	}

--- a/pkg/uevent/uevent.go
+++ b/pkg/uevent/uevent.go
@@ -21,6 +21,7 @@ const (
 	uEventDevPath   = "DEVPATH"
 	uEventSubSystem = "SUBSYSTEM"
 	uEventSeqNum    = "SEQNUM"
+	uEventDevName   = "DEVNAME"
 
 	paramDelim = 0x00
 )
@@ -69,6 +70,7 @@ type Uevent struct {
 	DevPath   string
 	SubSystem string
 	SeqNum    string
+	DevName   string
 }
 
 // Handler represents a uevent handler.
@@ -129,6 +131,8 @@ func (h *Handler) Read() (*Uevent, error) {
 			uEv.DevPath = val
 		case uEventSubSystem:
 			uEv.SubSystem = val
+		case uEventDevName:
+			uEv.DevName = val
 		case uEventSeqNum:
 			uEv.SeqNum = val
 


### PR DESCRIPTION
This PR gets rid of the device name prediction needed on the host side for block devices. This can be used for device handler that we add in the future including VFIO.

Fixes #198