### PR TITLE
agent: Add support for ephemeral volumes

### DIFF
--- a/device.go
+++ b/device.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	driver9pType   = "9p"
-	driverBlkType  = "blk"
-	driverSCSIType = "scsi"
+	driver9pType        = "9p"
+	driverBlkType       = "blk"
+	driverSCSIType      = "scsi"
+	driverEphemeralType = "ephemeral"
 )
 
 const rootBusPath = "/devices/pci0000:00"

--- a/mount_test.go
+++ b/mount_test.go
@@ -30,6 +30,22 @@ func createSafeAndFakeStorage() (pb.Storage, error) {
 	}, nil
 }
 
+func TestEphemeralStorageHandlerSuccessful(t *testing.T) {
+	skipUnlessRoot(t)
+
+	storage, err := createSafeAndFakeStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Unmount(storage.MountPoint, 0)
+	defer os.RemoveAll(storage.MountPoint)
+
+	storage.Fstype = typeTmpFs
+	storage.Source = typeTmpFs
+	_, err = ephemeralStorageHandler(storage, &sandbox{})
+	assert.Nil(t, err, "ephemeralStorageHandler() failed: %v", err)
+}
+
 func TestVirtio9pStorageHandlerSuccessful(t *testing.T) {
 	skipUnlessRoot(t)
 


### PR DESCRIPTION
Ephemeral volumes needs to mounted inside VM
and not passed as 9pfs mounts.

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>