### PR TITLE
grpc: log errors in async commands

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -75,9 +75,9 @@ const onlineCPUMaxTries = 10
 
 const dockerCpusetMode = 0644
 
-// handleError will log the specified error if wait is true
+// handleError will log the specified error if wait is false
 func handleError(wait bool, err error) error {
-	if wait {
+	if !wait {
 		agentLog.WithError(err).Error()
 	}
 

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -320,4 +321,21 @@ func TestStatsContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(r)
 
+}
+
+func TestHandleError(t *testing.T) {
+	assert := assert.New(t)
+
+	err := errors.New("")
+	e := handleError(true, err)
+	assert.Error(e)
+
+	e = handleError(true, nil)
+	assert.NoError(e)
+
+	e = handleError(false, err)
+	assert.Error(e)
+
+	e = handleError(false, nil)
+	assert.NoError(e)
 }


### PR DESCRIPTION
handleError function must log the errors when wait is false.

fixes #237

Signed-off-by: Julio Montes <julio.montes@intel.com>