### PR TITLE
namespaces: Create persistent UTS and IPC namespaces

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -78,12 +78,8 @@ type sandbox struct {
 	server          *grpc.Server
 	pciDeviceMap    map[string]string
 	deviceWatchers  map[string](chan string)
-}
-
-type namespace struct {
-	path       string
-	init       *os.Process
-	exitCodeCh <-chan int
+	sharedUTSNs     namespace
+	sharedIPCNs     namespace
 }
 
 var agentFields = logrus.Fields{
@@ -252,6 +248,36 @@ func (s *sandbox) readStdio(cid, execID string, length int, stdout bool) ([]byte
 	}
 
 	return buf[:bytesRead], nil
+}
+
+func (s *sandbox) setupSharedNamespaces() error {
+	// Set up shared IPC namespace
+	ns, err := setupPersistentNs(nsTypeIPC)
+	if err != nil {
+		return err
+	}
+	s.sharedIPCNs = *ns
+
+	// Set up shared UTS namespace
+	ns, err = setupPersistentNs(nsTypeUTS)
+	if err != nil {
+		return err
+	}
+	s.sharedUTSNs = *ns
+
+	return nil
+}
+
+func (s *sandbox) unmountSharedNamespaces() error {
+	if err := unix.Unmount(s.sharedIPCNs.path, unix.MNT_DETACH); err != nil {
+		return err
+	}
+
+	if err := unix.Unmount(s.sharedUTSNs.path, unix.MNT_DETACH); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // setupSharedPidNs will reexec this binary in order to execute the C routine

--- a/grpc.go
+++ b/grpc.go
@@ -395,6 +395,8 @@ func (a *agentGRPC) postExecProcess(ctr *container, proc *process) error {
 // sense to rely on the namespace path provided by the host since namespaces
 // are different inside the guest.
 func (a *agentGRPC) updateContainerConfigNamespaces(config *configs.Config) error {
+	var pidNs, ipcNs, utsNs bool
+
 	// Update shared PID namespace.
 	for idx, ns := range config.Namespaces {
 		if ns.Type == configs.NEWPID {
@@ -402,19 +404,46 @@ func (a *agentGRPC) updateContainerConfigNamespaces(config *configs.Config) erro
 			// the containers to share the same PID namespace, a
 			// new PID ns is going to be created.
 			config.Namespaces[idx].Path = a.sandbox.sharedPidNs.path
-			return nil
+			pidNs = true
+		}
+
+		if ns.Type == configs.NEWIPC {
+			config.Namespaces[idx].Path = a.sandbox.sharedIPCNs.path
+			ipcNs = true
+		}
+
+		if ns.Type == configs.NEWUTS {
+			config.Namespaces[idx].Path = a.sandbox.sharedUTSNs.path
+			utsNs = true
 		}
 	}
 
 	// If no NEWPID type was found, let's make sure we add it. Otherwise,
 	// the container could end up in the same PID namespace than the agent
 	// and we want to prevent this for security reasons.
-	newPidNs := configs.Namespace{
-		Type: configs.NEWPID,
-		Path: a.sandbox.sharedPidNs.path,
+	if !pidNs {
+		newPidNs := configs.Namespace{
+			Type: configs.NEWPID,
+			Path: a.sandbox.sharedPidNs.path,
+		}
+		config.Namespaces = append(config.Namespaces, newPidNs)
 	}
 
-	config.Namespaces = append(config.Namespaces, newPidNs)
+	if !ipcNs {
+		newIPCNs := configs.Namespace{
+			Type: configs.NEWIPC,
+			Path: a.sandbox.sharedIPCNs.path,
+		}
+		config.Namespaces = append(config.Namespaces, newIPCNs)
+	}
+
+	if !utsNs {
+		newUTSNs := configs.Namespace{
+			Type: configs.NEWUTS,
+			Path: a.sandbox.sharedUTSNs.path,
+		}
+		config.Namespaces = append(config.Namespaces, newUTSNs)
+	}
 
 	return nil
 }
@@ -985,6 +1014,11 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 	a.sandbox.network.dns = req.Dns
 	a.sandbox.running = true
 
+	// Set up shared UTS and IPC namespaces
+	if err := a.sandbox.setupSharedNamespaces(); err != nil {
+		return emptyResp, err
+	}
+
 	if req.SandboxPidns {
 		if err := a.sandbox.setupSharedPidNs(); err != nil {
 			return emptyResp, err
@@ -1030,6 +1064,10 @@ func (a *agentGRPC) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRe
 	}
 
 	if err := a.sandbox.teardownSharedPidNs(); err != nil {
+		return emptyResp, err
+	}
+
+	if err := a.sandbox.unmountSharedNamespaces(); err != nil {
 		return emptyResp, err
 	}
 

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -21,12 +21,20 @@ import (
 )
 
 var testSharedPidNs = "testSharedPidNs"
+var testSharedUTSNs = "testSharedUTSNs"
+var testSharedIPCNs = "testSharedIPCNs"
 
-func testUpdateContainerConfigNamespaces(t *testing.T, sharedPidNs string, config, expected configs.Config) {
+func testUpdateContainerConfigNamespaces(t *testing.T, sharedPidNs, sharedUTSNs, sharedIPCNs string, config, expected configs.Config) {
 	a := &agentGRPC{
 		sandbox: &sandbox{
 			sharedPidNs: namespace{
 				path: sharedPidNs,
+			},
+			sharedIPCNs: namespace{
+				path: sharedIPCNs,
+			},
+			sharedUTSNs: namespace{
+				path: sharedUTSNs,
 			},
 		},
 	}
@@ -45,6 +53,12 @@ func TestUpdateContainerConfigNamespacesNonEmptyConfig(t *testing.T) {
 			{
 				Type: configs.NEWPID,
 			},
+			{
+				Type: configs.NEWIPC,
+			},
+			{
+				Type: configs.NEWUTS,
+			},
 		},
 	}
 
@@ -54,10 +68,19 @@ func TestUpdateContainerConfigNamespacesNonEmptyConfig(t *testing.T) {
 				Type: configs.NEWPID,
 				Path: testSharedPidNs,
 			},
+
+			{
+				Type: configs.NEWIPC,
+				Path: testSharedIPCNs,
+			},
+			{
+				Type: configs.NEWUTS,
+				Path: testSharedUTSNs,
+			},
 		},
 	}
 
-	testUpdateContainerConfigNamespaces(t, testSharedPidNs, config, expectedConfig)
+	testUpdateContainerConfigNamespaces(t, testSharedPidNs, testSharedUTSNs, testSharedIPCNs, config, expectedConfig)
 }
 
 func TestUpdateContainerConfigNamespacesEmptyConfig(t *testing.T) {
@@ -67,10 +90,20 @@ func TestUpdateContainerConfigNamespacesEmptyConfig(t *testing.T) {
 				Type: configs.NEWPID,
 				Path: testSharedPidNs,
 			},
+
+			{
+				Type: configs.NEWIPC,
+				Path: testSharedIPCNs,
+			},
+			{
+				Type: configs.NEWUTS,
+				Path: testSharedUTSNs,
+			},
 		},
 	}
 
-	testUpdateContainerConfigNamespaces(t, testSharedPidNs, configs.Config{}, expectedConfig)
+	testUpdateContainerConfigNamespaces(t, testSharedPidNs, testSharedUTSNs, testSharedIPCNs, configs.Config{}, expectedConfig)
+	//testUpdateContainerConfigNamespaces(t, testSharedPidNs, configs.Config{}, expectedConfig)
 }
 
 func testUpdateContainerConfigPrivileges(t *testing.T, spec *specs.Spec, config, expected configs.Config) {

--- a/namespace.go
+++ b/namespace.go
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+var persistentNsDir = "/var/run"
+
+// nsType defines a namespace type.
+type nsType string
+
+type namespace struct {
+	path       string
+	init       *os.Process
+	exitCodeCh <-chan int
+}
+
+// List of namespace types.
+const (
+	nsTypeIPC nsType = "ipc"
+	nsTypeNet nsType = "net"
+	nsTypeUTS nsType = "uts"
+)
+
+var cloneFlagsTable = map[nsType]int{
+	nsTypeIPC: unix.CLONE_NEWIPC,
+	nsTypeNet: unix.CLONE_NEWNET,
+	nsTypeUTS: unix.CLONE_NEWUTS,
+}
+
+func getCurrentThreadNSPath(nType nsType) string {
+	return fmt.Sprintf("/proc/%d/task/%d/ns/%s", os.Getpid(), unix.Gettid(), nType)
+}
+
+// setupPersistentNs creates persistent namespace without switchin to it.
+// Note, pid namespaces cannot be persisted.
+func setupPersistentNs(namespaceType nsType) (*namespace, error) {
+	b := make([]byte, 8)
+	_, err := rand.Reader.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random netns name: %v", err)
+	}
+
+	err = os.MkdirAll(persistentNsDir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an empty file at the mount point.
+	nsPath := filepath.Join(persistentNsDir, fmt.Sprintf("%x", b))
+	mountFd, err := os.Create(nsPath)
+	if err != nil {
+		return nil, err
+	}
+	mountFd.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go (func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+
+		var origNsFd *os.File
+		origNsPath := getCurrentThreadNSPath(namespaceType)
+		origNsFd, err = os.Open(origNsPath)
+		if err != nil {
+			return
+		}
+		defer origNsFd.Close()
+
+		// Create a new netns on the current thread.
+		err = unix.Unshare(cloneFlagsTable[namespaceType])
+		if err != nil {
+			return
+		}
+
+		// Bind mount the new namespace from the current thread onto the mount point to persist it.
+		err = unix.Mount(getCurrentThreadNSPath(namespaceType), nsPath, "none", unix.MS_BIND, "")
+		if err != nil {
+			return
+		}
+
+		// Switch back to original namespace.
+		if err = unix.Setns(int(origNsFd.Fd()), cloneFlagsTable[namespaceType]); err != nil {
+			return
+		}
+
+	})()
+	wg.Wait()
+
+	if err != nil {
+		unix.Unmount(nsPath, unix.MNT_DETACH)
+		return nil, fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	return &namespace{path: nsPath}, nil
+}

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestSetupPersistentNs(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test disabled as it requires root privileges")
+	}
+
+	ipcDirPath, err := ioutil.TempDir("", "ipc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(ipcDirPath)
+
+	persistentNsDir = ipcDirPath
+	ns, err := setupPersistentNs(nsTypeIPC)
+	assert.Nil(t, err, "setupPersistentNs failed for IPC namespace: %v", err)
+
+	assert.NotNil(t, ns.path, "Path empty for persistent IPC namespace")
+	err = unix.Unmount(ns.path, unix.MNT_DETACH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	utsDirPath, err := ioutil.TempDir("", "uts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(utsDirPath)
+
+	persistentNsDir = utsDirPath
+	ns, err = setupPersistentNs(nsTypeUTS)
+	assert.Nil(t, err, "setupPersistentNs failed for UTS namespace: %v", err)
+
+	assert.NotNil(t, ns.path, "Path empty for persistent UTS namespace")
+	err = unix.Unmount(ns.path, unix.MNT_DETACH)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
All containers in a pod need to share UTS and IPC
namespaces. Create these as persistent namespaces by bind-mounting
them to a persistent path and make all containers join these.

Fixes #248

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>