### PR TITLE
network: Setup localhost when running as init

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -820,19 +820,19 @@ func realMain() {
 
 	if err = s.initLogger(); err != nil {
 		agentLog.WithError(err).Error("failed to setup logger")
-		return
+		os.Exit(1)
 	}
 
 	if err = s.setupSignalHandler(); err != nil {
 		agentLog.WithError(err).Error("failed to setup signal handler")
-		return
+		os.Exit(1)
 	}
 
 	// Check for vsock vs serial. This will fill the sandbox structure with
 	// information about the channel.
 	if err = s.initChannel(); err != nil {
 		agentLog.WithError(err).Error("failed to setup channels")
-		return
+		os.Exit(1)
 	}
 
 	// Start gRPC server.

--- a/agent.go
+++ b/agent.go
@@ -828,6 +828,11 @@ func realMain() {
 		os.Exit(1)
 	}
 
+	if err = s.handleLocalhost(); err != nil {
+		agentLog.WithError(err).Error("failed to handle localhost")
+		os.Exit(1)
+	}
+
 	// Check for vsock vs serial. This will fill the sandbox structure with
 	// information about the channel.
 	if err = s.initChannel(); err != nil {

--- a/agent.go
+++ b/agent.go
@@ -293,11 +293,7 @@ func (s *sandbox) unmountSharedNamespaces() error {
 		return err
 	}
 
-	if err := unix.Unmount(s.sharedUTSNs.path, unix.MNT_DETACH); err != nil {
-		return err
-	}
-
-	return nil
+	return unix.Unmount(s.sharedUTSNs.path, unix.MNT_DETACH)
 }
 
 // setupSharedPidNs will reexec this binary in order to execute the C routine

--- a/network.go
+++ b/network.go
@@ -60,8 +60,16 @@ func linkByHwAddr(netHandle *netlink.Handle, hwAddr string) (netlink.Link, error
 	}
 
 	for _, link := range links {
+		if link == nil {
+			continue
+		}
+
 		lAttrs := link.Attrs()
 		if lAttrs == nil {
+			continue
+		}
+
+		if lAttrs.HardwareAddr == nil {
 			continue
 		}
 

--- a/network.go
+++ b/network.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
 	"reflect"
 	"sync"
 
@@ -564,4 +565,20 @@ func (s *sandbox) removeNetwork() error {
 	}
 
 	return nil
+}
+
+// Bring up localhost network interface.
+func (s *sandbox) handleLocalhost() error {
+	// If not running as the init daemon, there is nothing to do as the
+	// localhost interface will already exist.
+	if os.Getpid() != 1 {
+		return nil
+	}
+
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		return err
+	}
+
+	return netlink.LinkSetUp(lo)
 }


### PR DESCRIPTION
When the agent is running as PID 1 it needs to setup the localhost
network interface. If not done, not only will "lo" not be available, but
the netlink library will cause the agent to segfault as it implicitly
assumes `lo` is "up".

Also added in extra parameter validation and error handling improvements.

Fixes #265.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
