### PR TITLE
mount: Remove redundant mkdir

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -717,9 +717,6 @@ func mountToRootfs(m initMount) error {
 
 func generalMount() error {
 	for _, m := range initRootfsMounts {
-		if err := os.MkdirAll(m.dest, os.FileMode(0755)); err != nil {
-			return err
-		}
 		if err := mountToRootfs(m); err != nil {
 			return err
 		}


### PR DESCRIPTION
Don't create the mount destination in `generalMount()` as that is
handled by `mountToRootfs()`.

Fixes #267.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>