### PR TITLE
agent: honour CPU constraints when agent is the init process

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -40,8 +40,13 @@ import (
 
 const (
 	procCgroups = "/proc/cgroups"
-	cgroupPath  = "/sys/fs/cgroup"
 	meminfo     = "/proc/meminfo"
+)
+
+var (
+	// cgroup fs is mounted at /sys/fs when systemd is the init process
+	cgroupPath      = "/sys/fs/cgroup"
+	sysfsCpusetPath = cgroupPath + "/cpuset"
 )
 
 var initRootfsMounts = []initMount{
@@ -758,6 +763,10 @@ func initAgentAsInit() error {
 	syscall.Setsid()
 	syscall.Syscall(syscall.SYS_IOCTL, os.Stdin.Fd(), syscall.TIOCSCTTY, 1)
 	os.Setenv("PATH", "/bin:/sbin/:/usr/bin/:/usr/sbin/")
+
+	// when agent runs as init process, cgroup fs is mounted at /proc
+	cgroupPath = "/proc/cgroup"
+	sysfsCpusetPath = cgroupPath + "/cpuset"
 
 	return announce()
 }

--- a/grpc.go
+++ b/grpc.go
@@ -56,7 +56,6 @@ var (
 	sysfsCPUOnlinePath     = "/sys/devices/system/cpu"
 	sysfsMemOnlinePath     = "/sys/devices/system/memory"
 	sysfsConnectedCPUsPath = filepath.Join(sysfsCPUOnlinePath, "online")
-	sysfsCpusetPath        = "/sys/fs/cgroup/cpuset"
 )
 
 type onlineResource struct {


### PR DESCRIPTION
When agent runs as init process cgroup fs is mounted at /proc,
OnlineCPUMem must be able to support both paths, /proc and /sys/fs.

fixes #262

Signed-off-by: Julio Montes <julio.montes@intel.com>