### PR TITLE
CI: update static-checks.sh in .ci/lib.sh

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -21,7 +21,7 @@ clone_tests_repo()
 run_static_checks()
 {
 	clone_tests_repo
-	bash "$tests_repo_dir/.ci/static-checks.sh"
+	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/agent"
 }
 
 run_go_test()


### PR DESCRIPTION
Now static-checks.sh needs to have the
repository name as argument.

Fixes #274.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>