### PR TITLE
grpc: Don't close the terminal on CloseStdin() call

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -58,6 +58,8 @@ var initRootfsMounts = []initMount{
 }
 
 type process struct {
+	sync.RWMutex
+
 	id          string
 	process     libcontainer.Process
 	stdin       *os.File
@@ -66,6 +68,7 @@ type process struct {
 	consoleSock *os.File
 	termMaster  *os.File
 	exitCodeCh  chan int
+	stdinClosed bool
 }
 
 type container struct {

--- a/grpc.go
+++ b/grpc.go
@@ -1089,14 +1089,13 @@ func (a *agentGRPC) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (
 		return emptyResp, err
 	}
 
-	var file *os.File
-	if proc.termMaster != nil {
-		file = proc.termMaster
-	} else {
-		file = proc.stdin
+	// If stdin is nil, which can be the case when using a terminal,
+	// there is nothing to do.
+	if proc.stdin == nil {
+		return emptyResp, nil
 	}
 
-	if err := file.Close(); err != nil {
+	if err := proc.stdin.Close(); err != nil {
 		return emptyResp, err
 	}
 


### PR DESCRIPTION
CloseStdin() is supposed to close only the standard input, which
helps the process to terminate in some cases. But for the case where
we are using a terminal, it should be closed by the agent once the
WaitProcess() will complete. Otherwise, closing it before the end of
the process could prevent some output from the terminal to reach the
shim.

Fixes #283

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>