### PR TITLE
logging: Add sandbox field

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ const (
 	optionPrefix      = "agent."
 	logLevelFlag      = optionPrefix + "log"
 	devModeFlag       = optionPrefix + "devmode"
+	sandboxFlag       = optionPrefix + "sandbox"
 	kernelCmdlineFile = "/proc/cmdline"
 )
 
@@ -94,6 +95,8 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 		if level == logrus.DebugLevel {
 			debug = true
 		}
+	case sandboxFlag:
+		agentLog = agentLog.WithField("sandbox", split[valuePosition])
 	default:
 		if strings.HasPrefix(split[optionPosition], optionPrefix) {
 			return grpcStatus.Errorf(codes.NotFound, "Unknown option %s", split[optionPosition])


### PR DESCRIPTION
Read the sandbox ID from the `agent.sandbox=` kernel command-line
option and add a `sandbox=` log field with this value.

This makes the logs more useful as every agent entry is now tied to a
sandboxID.

Fixes #291.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>