### PR TITLE
agent: disable yamux keep alive

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -147,7 +147,10 @@ func agentDialer(addr *url.URL, enableYamux bool) dialer {
 		}()
 
 		var session *yamux.Session
-		session, err = yamux.Client(conn, nil)
+		sessionConfig := yamux.DefaultConfig()
+		// Disable keepAlive since we don't know how much time a container can be paused
+		sessionConfig.EnableKeepAlive = false
+		session, err = yamux.Client(conn, sessionConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We don't know how much time a sandbox can be paused,
hence connection write timeout should be disabled to
don't close the connection while the sandbox is paused.

The same issue has been fixed in kata-proxy, for katabuiltin proxy,
it also needs this fix.

fixes #294

Signed-off-by: fupan <lifupan@gmail.com>