### PR TITLE
agent: Fix CPU tests for both initrd and rootfs image

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -45,8 +45,8 @@ const (
 
 var (
 	// cgroup fs is mounted at /sys/fs when systemd is the init process
-	cgroupPath      = "/sys/fs/cgroup"
-	sysfsCpusetPath = cgroupPath + "/cpuset"
+	cgroupPath       = "/sys/fs/cgroup"
+	cgroupCpusetPath = cgroupPath + "/cpuset"
 )
 
 var initRootfsMounts = []initMount{
@@ -772,10 +772,6 @@ func initAgentAsInit() error {
 	syscall.Setsid()
 	syscall.Syscall(syscall.SYS_IOCTL, os.Stdin.Fd(), syscall.TIOCSCTTY, 1)
 	os.Setenv("PATH", "/bin:/sbin/:/usr/bin/:/usr/sbin/")
-
-	// when agent runs as init process, cgroup fs is mounted at /proc
-	cgroupPath = "/proc/cgroup"
-	sysfsCpusetPath = cgroupPath + "/cpuset"
 
 	return announce()
 }

--- a/grpc.go
+++ b/grpc.go
@@ -161,7 +161,7 @@ func onlineMemResources() error {
 // don't update a cgroup twice.
 func updateContainerCpuset(cgroupPath string, newCpuset string, cookies cookie) error {
 	// Each cpuset cgroup MUST BE updated with the actual number of vCPUs.
-	cpusetPath := sysfsCpusetPath
+	cpusetPath := cgroupCpusetPath
 	cgroupsPaths := strings.Split(cgroupPath, "/")
 	for _, path := range cgroupsPaths {
 		// Skip if empty.

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -261,13 +261,13 @@ func TestOnlineCPUMem(t *testing.T) {
 	_, err = a.OnlineCPUMem(context.TODO(), req)
 	assert.Error(err, "docker cgroup path does not exist")
 
-	sysfsCpusetPath, err = ioutil.TempDir("", "cgroup")
+	cgroupCpusetPath, err = ioutil.TempDir("", "cgroup")
 	assert.NoError(err)
 	cfg := container.container.Config()
-	cgroupPath := filepath.Join(sysfsCpusetPath, cfg.Cgroups.Path)
+	cgroupPath := filepath.Join(cgroupCpusetPath, cfg.Cgroups.Path)
 	err = os.MkdirAll(cgroupPath, 0777)
 	assert.NoError(err)
-	defer os.RemoveAll(sysfsCpusetPath)
+	defer os.RemoveAll(cgroupCpusetPath)
 
 	err = ioutil.WriteFile(memory0Online, []byte("0"), 0755)
 	assert.NoError(err)
@@ -498,12 +498,12 @@ func TestUpdateContainerCpuset(t *testing.T) {
 	var err error
 	assert := assert.New(t)
 
-	sysfsCpusetPath, err = ioutil.TempDir("", "cgroup")
+	cgroupCpusetPath, err = ioutil.TempDir("", "cgroup")
 	assert.NoError(err)
-	defer os.Remove(sysfsCpusetPath)
+	defer os.Remove(cgroupCpusetPath)
 
 	cgroupPath := "kata"
-	err = os.MkdirAll(filepath.Join(sysfsCpusetPath, cgroupPath), 0777)
+	err = os.MkdirAll(filepath.Join(cgroupCpusetPath, cgroupPath), 0777)
 	assert.NoError(err)
 
 	cookies := make(cookie)


### PR DESCRIPTION
Now cgroups are mounted at /sys/fs/cgroup, in the past
when initrd was used cgroups were mounted at /proc/cgroups

fixes #282

Signed-off-by: Julio Montes <julio.montes@intel.com>