### PR TITLE
protocols: increase dial timeout

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -28,7 +28,7 @@ const (
 	vsockSocketScheme = "vsock"
 )
 
-var defaultDialTimeout = 5 * time.Second
+var defaultDialTimeout = 15 * time.Second
 
 // AgentClient is an agent gRPC client connection wrapper for agentgrpc.AgentServiceClient
 type AgentClient struct {


### PR DESCRIPTION
Run containers that use vsock as communication channel inside VMs
(nested environments) randomly fails with following error:

```
Stderr: docker: Error response from daemon: OCI runtime create failed:
Failed to check if grpc server is working: context deadline exceeded: unknown.
```

Sometimes the connection with the container's vsock is slow because of
kata-runtime disables modern (don't rely on fast MMIO) on some devices
including vsocks. This issue can be fixed by increasing the dial timeout.

fixes #324

Signed-off-by: Julio Montes <julio.montes@intel.com>