### PR TITLE
vendor: Update dep lock file for new format

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   revision = "84eeaae905fa414d03e07bcd6c8d3f19e7cf180e"
 
 [[projects]]
-  digest = "1:998aa7312fc20dff58d0894b85a87618401be5e02ec610a48fed33a146c22d93"
+  digest = "1:5745ae844cff2e5063ff983e8a39f12200d97a41a23d5e94169bc776c24a6580"
   name = "github.com/coreos/go-systemd"
   packages = [
     "dbus",
@@ -61,7 +61,7 @@
   version = "v4.1.0"
 
 [[projects]]
-  digest = "1:6fb326814b2c00537e05c1c6aceb8d2ecb686fdcd41cf4b226cc41058664226f"
+  digest = "1:b41b8ae04e4fb929a0b20df6fb72a735458c68d58eab6e93e3411410578d9b66"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -75,7 +75,7 @@
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
 
 [[projects]]
-  digest = "1:62c39e48b3af4ccc5f20819b3fc4b7aee88cf4b7e296c4be0168113e755adfaa"
+  digest = "1:0d390d7037c2aecc37e78c2cfbe43d020d6f1fa83fd22266b7ec621189447d57"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -110,7 +110,7 @@
   revision = "7d4729fb36185a7c1719923406c9d40e54fb93c7"
 
 [[projects]]
-  digest = "1:4ab9c2f8b2099727d73baf1ddb375c7a99c44e7a9ba3857673b214c60a4851a4"
+  digest = "1:e9efda6418044c653a9d6051719196214dbdbe4fa50ebcc7975dde8932b6d2f5"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer",
@@ -143,7 +143,7 @@
   revision = "4e3b9264a330d094b0386c3703c5f379119711e8"
 
 [[projects]]
-  digest = "1:bf581d0c4c0545f7d2e46d9d0df4dafc92c24ed6b1e2fb66ab4bc91acd072e64"
+  digest = "1:5c65c485fa22fdfd6937db07aaf879904a4745770ee416d8d1f2a1434dc2d8ce"
   name = "github.com/opencontainers/selinux"
   packages = [
     "go-selinux",
@@ -200,7 +200,7 @@
   revision = "db04d3cc01c8b54962a58ec7e491717d06cfcc16"
 
 [[projects]]
-  digest = "1:b097acf40a3ea6c97a1670f19c39d8756aac94e70219f0d8838222aba3a02aad"
+  digest = "1:2102a6328eb29d39c528696fe92fb347d5bc5a10b181ced1f80ffaabec45d538"
   name = "github.com/vishvananda/netlink"
   packages = [
     ".",
@@ -226,7 +226,7 @@
   revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
 
 [[projects]]
-  digest = "1:5985d67e107c875e2584b5a65f1590adee7677a4e44eb7e62cd54c7709abba4a"
+  digest = "1:b20c63a56900e442d5f435613fefc9392cbe8849467510fcc3869dbdad9441bb"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -241,7 +241,7 @@
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
-  digest = "1:64107e3c8f52f341891a565d117bf263ed396fe0c16bad19634b25be25debfaa"
+  digest = "1:5420733d35e5e562fffc7c5b99660f3587af042b5420f19b17fe0426e6a5259d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -252,7 +252,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c3b44d72b3c13bed2937c314210b758bc292859a6bf6c80f073d46354c1d5168"
+  digest = "1:b2d78fc58a30271a4c1b8b1daf5f4db2a09e9fb57b2c8b7a90f632951ee3699b"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -282,7 +282,7 @@
   revision = "7f0da29060c682909f650ad8ed4e515bd74fa12a"
 
 [[projects]]
-  digest = "1:7ac7635ce6308d286edb1998a8832d79a4f0ddb1e6139284042464840ed17d21"
+  digest = "1:abbcaa84ed484e328cef0cd0bc0130641edc52b4bc6bfb0090dadfd2c1033b6f"
   name = "google.golang.org/grpc"
   packages = [
     ".",


### PR DESCRIPTION
NOP update that simply updates the file format of the `dep` `Gopkg.lock`
file to the latest format.

Note: `dep ensure` run using `dep` at commit golang/dep@6b79ccc.

Fixes #325.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>