### PR TITLE
Stable 1.2.1 candidate

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -44,8 +44,11 @@ const (
 
 var (
 	// cgroup fs is mounted at /sys/fs when systemd is the init process
-	cgroupPath       = "/sys/fs/cgroup"
-	cgroupCpusetPath = cgroupPath + "/cpuset"
+	cgroupPath                   = "/sys/fs/cgroup"
+	cgroupCpusetPath             = cgroupPath + "/cpuset"
+	cgroupMemoryPath             = cgroupPath + "/memory"
+	cgroupMemoryUseHierarchyPath = cgroupMemoryPath + "/memory.use_hierarchy"
+	cgroupMemoryUseHierarchyMode = os.FileMode(0400)
 )
 
 var initRootfsMounts = []initMount{
@@ -859,7 +862,10 @@ func cgroupsMount() error {
 			return err
 		}
 	}
-	return nil
+
+	// Enable memory hierarchical account.
+	// For more information see https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+	return ioutil.WriteFile(cgroupMemoryUseHierarchyPath, []byte{'1'}, cgroupMemoryUseHierarchyMode)
 }
 
 // initAgentAsInit will do the initializations such as setting up the rootfs

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -28,7 +28,7 @@ const (
 	vsockSocketScheme = "vsock"
 )
 
-var defaultDialTimeout = 5 * time.Second
+var defaultDialTimeout = 15 * time.Second
 
 // AgentClient is an agent gRPC client connection wrapper for agentgrpc.AgentServiceClient
 type AgentClient struct {


### PR DESCRIPTION
Smaller set -- pulled each of the commits from 1.2.0 to HEAD (cd8f37b).  

Analysis:
 1.2.1 | * 93fe84e protocols: increase dial timeout
NO:  | * 730b977 client: bypass grpc dialer backoff strategy
1.2.1  | * 41c09c2 agent: enable memory hierarchical account

NO    | * 4f70b1c channel: remove unused functions
NO:   | * f6486e7 channel: support communication channel hotplug
 