### PR TITLE
agent: allow multiple waitProcess()

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -70,6 +70,7 @@ type process struct {
 	consoleSock *os.File
 	termMaster  *os.File
 	exitCodeCh  chan int
+	sync.Once
 	stdinClosed bool
 }
 

--- a/grpc.go
+++ b/grpc.go
@@ -768,17 +768,19 @@ func (a *agentGRPC) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest)
 		return &pb.WaitProcessResponse{}, err
 	}
 
-	defer func() {
+	defer proc.Do(func() {
 		proc.closePostExitFDs()
 		ctr.deleteProcess(proc.id)
-	}()
+	})
 
 	// Using helper function wait() to deal with the subreaper.
 	libContProcess := (*reaperLibcontainerProcess)(&(proc.process))
-	exitCode, err := a.sandbox.subreaper.wait(proc.exitCodeCh, libContProcess)
-	if err != nil {
-		return &pb.WaitProcessResponse{}, err
-	}
+	exitCode, _ := a.sandbox.subreaper.wait(proc.exitCodeCh, libContProcess)
+	//refill the exitCodeCh with the exitcode which can be read out
+	//by another WaitProcess(). Since this channel isn't be closed,
+	//here the refill will always success and it will be free by GC
+	//once the process exits.
+	proc.exitCodeCh <- exitCode
 
 	return &pb.WaitProcessResponse{
 		Status: int32(exitCode),

--- a/reaper.go
+++ b/reaper.go
@@ -140,8 +140,6 @@ func (r *agentReaper) reap() error {
 		// of the process and return the exit code to the
 		// caller of WaitProcess().
 		exitCodeCh <- status
-
-		close(exitCodeCh)
 	}
 }
 


### PR DESCRIPTION
There will be multiple waitProcess() requests
issued before process exits, and all those requests
should be fulfilled.

Fixes: #129
Fixes: #333

Signed-off-by: fupan <lifupan@gmail.com>