### PR TITLE
agent: write OCI spec to config.json in bundle path

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -524,6 +524,35 @@ func (a *agentGRPC) rollbackFailingContainerCreation(ctr *container) {
 	}
 }
 
+func finishCreateContainer(a *agentGRPC, ctr *container, req *pb.CreateContainerRequest, config *configs.Config) (resp *gpb.Empty, err error) {
+	containerPath := filepath.Join("/tmp/libcontainer", a.sandbox.id)
+	factory, err := libcontainer.New(containerPath, libcontainer.Cgroupfs)
+	if err != nil {
+		return emptyResp, err
+	}
+
+	ctr.container, err = factory.Create(req.ContainerId, config)
+	if err != nil {
+		return emptyResp, err
+	}
+	ctr.config = *config
+
+	ctr.initProcess, err = buildProcess(req.OCI.Process, req.ExecId)
+	if err != nil {
+		return emptyResp, err
+	}
+
+	if err = a.execProcess(ctr, ctr.initProcess, true); err != nil {
+		return emptyResp, err
+	}
+
+	if err := a.updateSharedPidNs(ctr); err != nil {
+		return emptyResp, err
+	}
+
+	return emptyResp, a.postExecProcess(ctr, ctr.initProcess)
+}
+
 func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (resp *gpb.Empty, err error) {
 	if err := a.createContainerChecks(req); err != nil {
 		return emptyResp, err
@@ -579,6 +608,13 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		return emptyResp, err
 	}
 
+	// Change cwd because libcontainer sets the bundle path to cwd
+	oldcwd, err := pb.ChangeToBundlePath(ociSpec)
+	if err != nil {
+		return emptyResp, err
+	}
+	defer os.Chdir(oldcwd)
+
 	// Convert the OCI specification into a libcontainer configuration.
 	config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
 		CgroupName:   req.ContainerId,
@@ -590,38 +626,21 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		return emptyResp, err
 	}
 
+	// In order to comply with the OCI specification, the spec must be
+	// written to a file named 'config.json' located in the bundle
+	// directory. https://github.com/opencontainers/runtime-spec
+	err = pb.WriteSpecToFile(ociSpec)
+	if err != nil {
+		return emptyResp, err
+	}
+
 	// Update libcontainer configuration for specific cases not handled
 	// by the specconv converter.
 	if err = a.updateContainerConfig(ociSpec, config, ctr); err != nil {
 		return emptyResp, err
 	}
 
-	containerPath := filepath.Join("/tmp/libcontainer", a.sandbox.id)
-	factory, err := libcontainer.New(containerPath, libcontainer.Cgroupfs)
-	if err != nil {
-		return emptyResp, err
-	}
-
-	ctr.container, err = factory.Create(req.ContainerId, config)
-	if err != nil {
-		return emptyResp, err
-	}
-	ctr.config = *config
-
-	ctr.initProcess, err = buildProcess(req.OCI.Process, req.ExecId)
-	if err != nil {
-		return emptyResp, err
-	}
-
-	if err = a.execProcess(ctr, ctr.initProcess, true); err != nil {
-		return emptyResp, err
-	}
-
-	if err := a.updateSharedPidNs(ctr); err != nil {
-		return emptyResp, err
-	}
-
-	return emptyResp, a.postExecProcess(ctr, ctr.initProcess)
+	return finishCreateContainer(a, ctr, req, config)
 }
 
 func (a *agentGRPC) createContainerChecks(req *pb.CreateContainerRequest) (err error) {


### PR DESCRIPTION
In order to comply with the OCI specification, the spec must be written to a file named 'config.json' located in the bundle directory.

Signed-off-by: Edward Guzman <eguzman@nvidia.com>