### PR TITLE
CI: Add "make proto"

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -11,4 +11,7 @@ source "${cidir}/lib.sh"
 
 pushd "${tests_repo_dir}"
 .ci/run.sh
+testcidir=$(dirname "$0")
+"${testcidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r runc -f
 popd
+make proto

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-image:
 	docker build ${BUILDARGS} -t ${AGENT_IMAGE}:${AGENT_TAG} .
 
 proto: build-image
-	docker run -ti -v ${PWD}:/go/src/github.com/kata-containers/agent ${AGENT_IMAGE}:${AGENT_TAG} ./hack/update-generated-agent-proto.sh
+	docker run -i -v ${PWD}:/go/src/github.com/kata-containers/agent ${AGENT_IMAGE}:${AGENT_TAG} ./hack/update-generated-agent-proto.sh
 
 .PHONY: clean test
 clean:


### PR DESCRIPTION
Allow make proto to work under the CI. So later we are able to check
pb.go files in CI.

fixes #340

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>
