### PR TITLE
fix uevent related errors

### DIFF
--- a/device.go
+++ b/device.go
@@ -112,14 +112,23 @@ func getPCIDeviceName(s *sandbox, pciID string) (string, error) {
 
 	fieldLogger := agentLog.WithField("pciID", pciID)
 
-	// Check if the PCI identifier is in PCI device map.
 	s.Lock()
+	// Check if the PCI identifier is in PCI device map.
 	for key, value := range s.pciDeviceMap {
 		if strings.Contains(key, pciAddr) {
 			devName = value
 			fieldLogger.Info("Device found in pci device map")
 			break
 		}
+	}
+
+	// Check if the PCI path is present before we setup the pci device map.
+	_, err = os.Stat(filepath.Join(rootBusPath, pciAddr))
+	if err == nil {
+		// Found pci path. It's there before we wait for the device map.
+		// We cannot find the name for it.
+		fieldLogger.Info("Device found on pci device path")
+		return "", nil
 	}
 
 	// If device is not found in the device map, hotplug event has not
@@ -159,6 +168,9 @@ func virtioBlkDeviceHandler(device pb.Device, spec *pb.Spec, s *sandbox) error {
 	devPath, err := getPCIDeviceName(s, device.Id)
 	if err != nil {
 		return err
+	}
+	if devPath == "" {
+		return fmt.Errorf("cannot find device name for virtio block device")
 	}
 	device.VmPath = devPath
 

--- a/device.go
+++ b/device.go
@@ -140,7 +140,6 @@ func getPCIDeviceName(s *sandbox, pciID string) (string, error) {
 		case <-time.After(time.Duration(timeoutHotplug) * time.Second):
 			s.Lock()
 			delete(s.deviceWatchers, pciAddr)
-			close(notifyChan)
 			s.Unlock()
 
 			return "", grpcStatus.Errorf(codes.DeadlineExceeded,

--- a/pkg/uevent/uevent.go
+++ b/pkg/uevent/uevent.go
@@ -56,7 +56,11 @@ func NewReaderCloser() (io.ReadCloser, error) {
 
 // Read implements reading function for uevent.
 func (r *ReaderCloser) Read(p []byte) (int, error) {
-	return unix.Read(r.fd, p)
+	count, err := unix.Read(r.fd, p)
+	if count < 0 && err != nil {
+		count = 0
+	}
+	return count, err
 }
 
 // Close implements closing function for uevent.


### PR DESCRIPTION
When testing network hotplug, I see some uevent listener related errors:
1. panic on closing the notification channels
2. device might appear before we listen to the uevents
3. panic on returning negative count in Read method to bufio

Note that even with this PR, network hotplug is still not working for me.

/cc @devimc @caoruidong @sboeuf 