### PR TITLE
wip: Revert "device: check for existing device PCI path before waiting"

### DIFF
--- a/device.go
+++ b/device.go
@@ -112,23 +112,14 @@ func getPCIDeviceName(s *sandbox, pciID string) (string, error) {
 
 	fieldLogger := agentLog.WithField("pciID", pciID)
 
-	s.Lock()
 	// Check if the PCI identifier is in PCI device map.
+	s.Lock()
 	for key, value := range s.pciDeviceMap {
 		if strings.Contains(key, pciAddr) {
 			devName = value
 			fieldLogger.Info("Device found in pci device map")
 			break
 		}
-	}
-
-	// Check if the PCI path is present before we setup the pci device map.
-	_, err = os.Stat(filepath.Join(rootBusPath, pciAddr))
-	if err == nil {
-		// Found pci path. It's there before we wait for the device map.
-		// We cannot find the name for it.
-		fieldLogger.Info("Device found on pci device path")
-		return "", nil
 	}
 
 	// If device is not found in the device map, hotplug event has not
@@ -168,9 +159,6 @@ func virtioBlkDeviceHandler(device pb.Device, spec *pb.Spec, s *sandbox) error {
 	devPath, err := getPCIDeviceName(s, device.Id)
 	if err != nil {
 		return err
-	}
-	if devPath == "" {
-		return fmt.Errorf("cannot find device name for virtio block device")
 	}
 	device.VmPath = devPath
 


### PR DESCRIPTION
We should not check for the sysfs path assciated with the PCI address
as the device node may still not be created. Only a uevent with a device
name associated indicates that the device is ready.

This change was also causing the sandbox lock to be not released causing
the uevent listening loop to be locked permanently.

This reverts commit 7caf1c8bd9ebad9ab6631e1839d62c8c98ed7d8a.