### PR TITLE
agent: support agent as init process in rootfs images

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -847,7 +847,11 @@ func mountToRootfs(m initMount) error {
 func generalMount() error {
 	for _, m := range initRootfsMounts {
 		if err := mountToRootfs(m); err != nil {
-			return err
+			// dev is already mounted if the rootfs image is used
+			if m.src != "dev" {
+				return err
+			}
+			agentLog.WithError(err).WithField("src", m.src).Warnf("Could not mount filesystem")
 		}
 	}
 	return nil


### PR DESCRIPTION
Don't fail if `dev` is already mounted

fixes #264

cc @jodh-intel @bergwolf 

Signed-off-by: Julio Montes <julio.montes@intel.com>