### PR TITLE
uevent: Add logs for uevents

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -479,6 +479,8 @@ func (s *sandbox) listenToUdevEvents() {
 	}
 	defer uEvHandler.Close()
 
+	fieldLogger.Infof("Started listening for uevents")
+
 	for {
 		uEv, err := uEvHandler.Read()
 		if err != nil {
@@ -498,6 +500,8 @@ func (s *sandbox) listenToUdevEvents() {
 			"uevent-seqnum":    uEv.SeqNum,
 			"uevent-devname":   uEv.DevName,
 		})
+
+		fieldLogger.Infof("Received add uevent")
 
 		// Check if device hotplug event results in a device node being created.
 		if uEv.DevName != "" && strings.HasPrefix(uEv.DevPath, rootBusPath) {


### PR DESCRIPTION
We should not receive many hotplug uevents. Log these so we can
track what devices have been attached in the logs.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>