### PR TITLE
Uevent fix for stable 1.1

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -372,6 +372,8 @@ func (s *sandbox) listenToUdevEvents() {
 	}
 	defer uEvHandler.Close()
 
+	fieldLogger.Infof("Started listening for uevents")
+
 	for {
 		uEv, err := uEvHandler.Read()
 		if err != nil {
@@ -386,6 +388,8 @@ func (s *sandbox) listenToUdevEvents() {
 			"uevent-seqnum":    uEv.SeqNum,
 			"uevent-devname":   uEv.DevName,
 		})
+
+		fieldLogger.Infof("Received add uevent")
 
 		// Check if device hotplug event results in a device node being created.
 		if uEv.DevName != "" && uEv.Action == "add" && strings.HasPrefix(uEv.DevPath, rootBusPath) {

--- a/device.go
+++ b/device.go
@@ -140,7 +140,6 @@ func getBlockDeviceNodeName(s *sandbox, pciID string) (string, error) {
 		case <-time.After(time.Duration(timeoutHotplug) * time.Second):
 			s.Lock()
 			delete(s.deviceWatchers, pciAddr)
-			close(notifyChan)
 			s.Unlock()
 
 			return "", grpcStatus.Errorf(codes.DeadlineExceeded,

--- a/device.go
+++ b/device.go
@@ -128,7 +128,7 @@ func getBlockDeviceNodeName(s *sandbox, pciID string) (string, error) {
 	// Note this is done inside the lock, not to miss any events from the
 	// global udev listener.
 	if devName == "" {
-		notifyChan := make(chan string, 1)
+		notifyChan = make(chan string, 1)
 		s.deviceWatchers[pciAddr] = notifyChan
 	}
 	s.Unlock()

--- a/device.go
+++ b/device.go
@@ -30,7 +30,11 @@ const (
 	driverEphemeralType = "ephemeral"
 )
 
-const rootBusPath = "/devices/pci0000:00"
+const (
+	rootBusPath      = "/devices/pci0000:00"
+	pciBusRescanFile = "/sys/bus/pci/rescan"
+	pciBusMode       = 0220
+)
 
 var (
 	sysBusPrefix     = "/sys/bus/pci/devices"
@@ -56,6 +60,10 @@ type deviceHandler func(device pb.Device, spec *pb.Spec, s *sandbox) error
 var deviceHandlerList = map[string]deviceHandler{
 	driverBlkType:  virtioBlkDeviceHandler,
 	driverSCSIType: virtioSCSIDeviceHandler,
+}
+
+func rescanPciBus() error {
+	return ioutil.WriteFile(pciBusRescanFile, []byte{'1'}, pciBusMode)
 }
 
 // getDevicePCIAddress fetches the complete PCI address in sysfs, based on the PCI
@@ -120,6 +128,13 @@ func getBlockDeviceNodeName(s *sandbox, pciID string) (string, error) {
 			fieldLogger.Info("Device found in pci device map")
 			break
 		}
+	}
+
+	// Rescan pci bus if we need to wait for a new pci device
+	if err = rescanPciBus(); err != nil {
+		fieldLogger.WithError(err).Error("Failed to scan pci bus")
+		s.Unlock()
+		return "", err
 	}
 
 	// If device is not found in the device map, hotplug event has not

--- a/device_test.go
+++ b/device_test.go
@@ -373,3 +373,12 @@ func TestAddDevice(t *testing.T) {
 		}
 	}
 }
+
+func TestRescanPciBus(t *testing.T) {
+	skipUnlessRoot(t)
+
+	assert := assert.New(t)
+
+	err := rescanPciBus()
+	assert.Nil(err)
+}

--- a/grpc.go
+++ b/grpc.go
@@ -40,12 +40,6 @@ type agentGRPC struct {
 	version string
 }
 
-// PCI scanning
-const (
-	pciBusRescanFile = "/sys/bus/pci/rescan"
-	pciBusMode       = 0220
-)
-
 // CPU and Memory hotplug
 const (
 	cpuRegexpPattern = "cpu[0-9]*"
@@ -527,7 +521,7 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 
 	// re-scan PCI bus
 	// looking for hidden devices
-	if err = ioutil.WriteFile(pciBusRescanFile, []byte("1"), pciBusMode); err != nil {
+	if err = rescanPciBus(); err != nil {
 		agentLog.WithError(err).Warn("Could not rescan PCI bus")
 	}
 

--- a/pkg/uevent/uevent.go
+++ b/pkg/uevent/uevent.go
@@ -55,7 +55,11 @@ func NewReaderCloser() (io.ReadCloser, error) {
 
 // Read implements reading function for uevent.
 func (r *ReaderCloser) Read(p []byte) (int, error) {
-	return unix.Read(r.fd, p)
+	count, err := unix.Read(r.fd, p)
+	if count < 0 && err != nil {
+		count = 0
+	}
+	return count, err
 }
 
 // Close implements closing function for uevent.


### PR DESCRIPTION
The PR back ports recent uevent related fixes to stable 1.1 branch, including following commits:

a628496 - [Peng Tao] device: rescan pci bus before waiting for new devices
1310f3d - [Peng Tao] device: fix redefined notify channel
ef62167 - [Archana Shinde] uevent: Add logs for uevents
2b89a0a - [Peng Tao] uevent: fix crash on read errors
3441244 - [Peng Tao] device: do not close notify channel when wait timeout