### PR TITLE
memory: Fix update memory path.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -44,7 +44,8 @@ const (
 
 var (
 	// cgroup fs is mounted at /sys/fs when systemd is the init process
-	cgroupPath                   = "/sys/fs/cgroup"
+	sysfsDir                     = "/sys"
+	cgroupPath                   = sysfsDir + "/fs/cgroup"
 	cgroupCpusetPath             = cgroupPath + "/cpuset"
 	cgroupMemoryPath             = cgroupPath + "/memory"
 	cgroupMemoryUseHierarchyPath = cgroupMemoryPath + "/memory.use_hierarchy"
@@ -56,7 +57,7 @@ var (
 
 var initRootfsMounts = []initMount{
 	{"proc", "proc", "/proc", []string{"nosuid", "nodev", "noexec"}},
-	{"sysfs", "sysfs", "/sys", []string{"nosuid", "nodev", "noexec"}},
+	{"sysfs", "sysfs", sysfsDir, []string{"nosuid", "nodev", "noexec"}},
 	{"devtmpfs", "dev", "/dev", []string{"nosuid"}},
 	{"tmpfs", "tmpfs", "/dev/shm", []string{"nosuid", "nodev"}},
 	{"devpts", "devpts", "/dev/pts", []string{"nosuid", "noexec"}},
@@ -541,9 +542,8 @@ func (s *sandbox) listenToUdevEvents() {
 			}
 
 			s.Unlock()
-		} else if strings.HasPrefix(uEv.DevPath, sysfsMemOnlinePath) {
+		} else if onlinePath := filepath.Join(sysfsDir, uEv.DevPath, "online"); strings.HasPrefix(onlinePath, sysfsMemOnlinePath) {
 			// Check memory hotplug and online if possible
-			onlinePath := filepath.Join("sys", uEv.DevPath, "online")
 			if err := ioutil.WriteFile(onlinePath, []byte("1"), 0600); err != nil {
 				fieldLogger.WithError(err).Error("failed online device")
 			}

--- a/device.go
+++ b/device.go
@@ -31,13 +31,13 @@ const (
 )
 
 const (
-	rootBusPath      = "/devices/pci0000:00"
-	pciBusRescanFile = "/sys/bus/pci/rescan"
-	pciBusMode       = 0220
+	rootBusPath = "/devices/pci0000:00"
+	pciBusMode  = 0220
 )
 
 var (
-	sysBusPrefix     = "/sys/bus/pci/devices"
+	sysBusPrefix     = sysfsDir + "/bus/pci/devices"
+	pciBusRescanFile = sysfsDir + "/bus/pci/rescan"
 	pciBusPathFormat = "%s/%s/pci_bus/"
 	systemDevPath    = "/dev"
 )
@@ -48,7 +48,7 @@ var (
 	// only one SCSI controller has been plugged, while the second number
 	// is always 0.
 	scsiHostChannel = "0:0:"
-	sysClassPrefix  = "/sys/class"
+	sysClassPrefix  = sysfsDir + "/class"
 	scsiDiskPrefix  = filepath.Join(sysClassPrefix, "scsi_disk", scsiHostChannel)
 	scsiBlockSuffix = "block"
 	scsiDiskSuffix  = filepath.Join("/device", scsiBlockSuffix)


### PR DESCRIPTION
When memory is hot added the udevpath is:

 uevent-devpath=/devices/system/memory/memory81

But when the agent checks for the path it expects it  checks
 in the /sys filesystem.

Fixes: #388

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>