### PR TITLE
agent: build as Position-Independent-Executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ ARCH := $(shell go env GOARCH)
 ifeq ($(SECCOMP),yes)
 BUILDTAGS := seccomp
 endif
+# go build common flags
+BUILDFLAGS := -buildmode=pie
 
 # args for building agent image
 BUILDARGS := $(if $(http_proxy), --build-arg http_proxy=$(http_proxy))
@@ -45,7 +47,7 @@ AGENT_IMAGE := katacontainers/agent-dev
 AGENT_TAG := $(if $(COMMIT_NO_SHORT),$(COMMIT_NO_SHORT),dev)
 
 $(TARGET): $(GENERATED_FILES) $(SOURCES) $(VERSION_FILE)
-	go build -tags "$(BUILDTAGS)" -o $@ \
+	go build $(BUILDFLAGS) -tags "$(BUILDTAGS)" -o $@ \
 		-ldflags "-X main.version=$(VERSION_COMMIT) -X main.seccompSupport=$(SECCOMP)"
 
 install:


### PR DESCRIPTION
Build the agent binary as Position-Independent-Executable (PIE) for improved
security and compliancy with distros packaging guidelines.

Fixes: #408