### PR TITLE
Update vendor/github.com/containerd/console

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,11 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:86feeb6c372fd7984322882737b00f32d7e75c6b437f93d75f43db3195574dab"
+  digest = "1:f366457ff35859c2de7fb1e7c0842595d55aa362c6174259f58a3cbf4cb7c727"
   name = "github.com/containerd/console"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "84eeaae905fa414d03e07bcd6c8d3f19e7cf180e"
+  revision = "2748ece16665b45a47f884001d5831ec79703880"
 
 [[projects]]
   digest = "1:5745ae844cff2e5063ff983e8a39f12200d97a41a23d5e94169bc776c24a6580"
@@ -101,6 +100,19 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "cc6d2ea263b2471faabce371255777a365bf8306"
+
+[[projects]]
+  branch = "master"
+  digest = "1:14dbca697f2f73a9c950d916b9b1299b3fabc4668a1b443a342e4df23466de41"
+  name = "github.com/kata-containers/agent"
+  packages = [
+    "pkg/types",
+    "pkg/uevent",
+    "protocols/grpc",
+    "protocols/mockserver",
+  ]
+  pruneopts = "NUT"
+  revision = "3bef6122c307bf1e562d5c645f45fb4bb66d8053"
 
 [[projects]]
   digest = "1:0159dcdabe50788e5dcfb469521f8f8dcd362db3ab6b465b99a3d33a90726fc0"
@@ -342,11 +354,16 @@
     "github.com/gogo/protobuf/types",
     "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc",
     "github.com/hashicorp/yamux",
+    "github.com/kata-containers/agent/pkg/types",
+    "github.com/kata-containers/agent/pkg/uevent",
+    "github.com/kata-containers/agent/protocols/grpc",
+    "github.com/kata-containers/agent/protocols/mockserver",
     "github.com/mdlayher/vsock",
     "github.com/opencontainers/runc/libcontainer",
     "github.com/opencontainers/runc/libcontainer/cgroups",
     "github.com/opencontainers/runc/libcontainer/configs",
     "github.com/opencontainers/runc/libcontainer/nsenter",
+    "github.com/opencontainers/runc/libcontainer/seccomp",
     "github.com/opencontainers/runc/libcontainer/specconv",
     "github.com/opencontainers/runc/libcontainer/utils",
     "github.com/opencontainers/runtime-spec/specs-go",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   name = "google.golang.org/grpc"
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
 
+[[override]]
+  name = "github.com/containerd/console"
+  revision = "2748ece16665b45a47f884001d5831ec79703880"
+
 [prune]
   non-go = true
   go-tests = true

--- a/vendor/github.com/containerd/console/tc_linux.go
+++ b/vendor/github.com/containerd/console/tc_linux.go
@@ -13,25 +13,21 @@ const (
 	cmdTcSet = unix.TCSETS
 )
 
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return err
 	}
 	return nil
 }
 
-// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
-// unlockpt should be called before opening the slave side of a pty.
-func unlockpt(f *os.File) error {
-	var u int32
-	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
-}
-
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
-	if err != nil {
+	var u uint32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}
-	return fmt.Sprintf("/dev/pts/%d", n), nil
+	return fmt.Sprintf("/dev/pts/%d", u), nil
 }


### PR DESCRIPTION
This PR fixes the issue https://github.com/kata-containers/agent/issues/410

The console package in vendor contains a big endian bug. The issue has
already been solved in runc. See PRs:
 - https://github.com/opencontainers/runc/pull/1727
 - https://github.com/containerd/console/pull/20

The console version has been updated from commit 84eeaae905 to commit
2748ece166 (commit that fixed the big-endian issue)

The console package has been added in the Gopkg.toml because the console
package is not directly used in the code and the dep command doesn't
automatically update the console package.

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>