### PR TITLE
grpc: sandbox: add container when is fully created.

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -560,6 +560,8 @@ func (a *agentGRPC) finishCreateContainer(ctr *container, req *pb.CreateContaine
 		return emptyResp, err
 	}
 
+	// Make sure add Container to Sandbox, before call updateSharedPidNs
+	a.sandbox.setContainer(req.ContainerId, ctr)
 	if err := a.updateSharedPidNs(ctr); err != nil {
 		return emptyResp, err
 	}
@@ -605,8 +607,6 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		mounts:          mountList,
 		useSandboxPidNs: req.SandboxPidns,
 	}
-
-	a.sandbox.setContainer(req.ContainerId, ctr)
 
 	// In case the container creation failed, make sure we cleanup
 	// properly by rolling back the actions previously performed.


### PR DESCRIPTION
Add container to sandbox list until it is created.

This commit makes sure to add the container to the sandbox until it is
created.

This helps to avoid other go routines uses the container structure with
nil pointers (because is not fully created).

Fixes: #417


Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>