### PR TITLE
network: check both interface name and mac address in updateInterface

### DIFF
--- a/network.go
+++ b/network.go
@@ -272,10 +272,17 @@ func (s *sandbox) updateInterface(netHandle *netlink.Handle, iface *types.Interf
 		// Find the interface link from its hardware address.
 		link, err = linkByHwAddr(netHandle, iface.HwAddr)
 		if err != nil {
-			return nil, grpcStatus.Errorf(codes.Internal, "updateInterface: %v", err)
+			return nil, grpcStatus.Errorf(codes.Internal, "updateInterface by HwAddr: %v", err)
+		}
+	} else if iface.Device != "" {
+		fieldLogger.Info("Getting interface from name")
+		// Find the interface link from its name.
+		link, err = netHandle.LinkByName(iface.Device)
+		if err != nil {
+			return nil, grpcStatus.Errorf(codes.Internal, "updateInterface byName: %v", err)
 		}
 	} else {
-		return nil, grpcStatus.Errorf(codes.InvalidArgument, "Interface HwAddr empty")
+		return nil, grpcStatus.Errorf(codes.InvalidArgument, "Interface HwAddr and Name are both empty")
 	}
 
 	// Use defer function to create and return the interface's state in


### PR DESCRIPTION
When passes a vf to qemu, the guest kernel driver(eg. mlx5) might
set the mac address. Thus without this patch, the updateInterface
in kata agent side will be failed and vfio-pci device can't be passed
to qemu command line

The fix includes 2 parts:
runtime side: set the mac address to null
agent side check the link name if the mac address is null

After setting null mac address in kata runtime, kata agent needs to
check the interface name if mac address is null.

Fixes: #413

Signed-off-by: Jia He <justin.he@arm.com>