### PR TITLE
agent: sync system clock with hwclock when creating new sandbox

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -853,6 +853,14 @@ func (s *sandbox) stopGRPC() {
 	}
 }
 
+func (s *sandbox) syncTimeHw2Sys() error {
+	cmd := &exec.Cmd{
+		Path: "/sbin/hwclock",
+		Args: []string{"hwclock", "--hctosys"},
+	}
+	return s.subreaper.run(cmd)
+}
+
 type initMount struct {
 	fstype, src, dest string
 	options           []string

--- a/grpc.go
+++ b/grpc.go
@@ -1211,6 +1211,10 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 		return emptyResp, grpcStatus.Error(codes.AlreadyExists, "Sandbox already started, impossible to start again")
 	}
 
+	if err := a.sandbox.syncTimeHw2Sys(); err != nil {
+		return emptyResp, err
+	}
+
 	a.sandbox.hostname = req.Hostname
 	a.sandbox.containers = make(map[string]*container)
 	a.sandbox.network.ifaces = make(map[string]*types.Interface)


### PR DESCRIPTION
The two might differ due to vm templating. We need to fix the
drift by setting system clock from hardware clock since kvmclock
should be trusted.

Depends-on: github.com/kata-containers/packaging#260
Depends-on: github.com/kata-containers/osbuilder#213
Fixes: #422

Signed-off-by: Peng Tao <bergwolf@gmail.com>