### PR TITLE
[DNM] agent: Properly stop the gRPC server

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -1341,6 +1341,10 @@ func (a *agentGRPC) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRe
 		return emptyResp, err
 	}
 
+	// Close stopServer channel to signal the main agent code to stop
+	// the server when all gRPC calls will be completed.
+	close(a.sandbox.stopServer)
+
 	a.sandbox.hostname = ""
 	a.sandbox.id = ""
 	a.sandbox.containers = make(map[string]*container)

--- a/kata-agent.service.in
+++ b/kata-agent.service.in
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 [Unit]
 Description=Kata Containers Agent
 Documentation=https://github.com/kata-containers/agent
@@ -10,5 +16,4 @@ StandardOutput=tty
 Type=simple
 ExecStart=@bindir@/@kata-agent@
 LimitNOFILE=infinity
-ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
-FailureAction=poweroff
+ExecStop=/bin/sync


### PR DESCRIPTION
This commit attempts to close cleanly the gRPC server so that tracing
will be ended properly.

Fixes #445

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>