### PR TITLE
ci: Add a CODEOWNERS file for github ack checks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Copyright 2019 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Define any code owners for this repository.
+# The code owners lists are used to help automatically enforce
+# reviews and acks of the right groups on the right PRs.
+
+# Order in this file is important. Only the last match will be
+# used. See https://help.github.com/articles/about-code-owners/
+
+*.md    @kata-containers/documentation
+


### PR DESCRIPTION
Add a CODEOWNERS file so we can get github to automatically
request reviews. In this instance, specifically the docs team
for markdown documents.

Fixes: #450

Signed-off-by: Graham Whaley <graham.whaley@intel.com>