### PR TITLE
wip: network: Wait till link is operationally up.

### DIFF
--- a/network_test.go
+++ b/network_test.go
@@ -22,6 +22,11 @@ import (
 func TestUpdateRemoveInterface(t *testing.T) {
 	skipUnlessRoot(t)
 
+	linkOperational = false
+	defer func() {
+		linkOperational = true
+	}()
+
 	s := sandbox{}
 
 	ifc := types.Interface{


### PR DESCRIPTION
Although we set the link up with LinkSetup, this function
returns before the link is actually up.
Additionally, besides the admin state of a network link, we
also need to check if the link is operationally up.
Namely we need to check if the netlink attribute IFLA_OPERSTATE is set
to IF_OPER_UP.

Fixes #458

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>