### PR TITLE
CODEOWNERS: add group review trigger for proto file changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,8 @@
 
 *.md    @kata-containers/documentation
 
+# All protocol changes need to get some review from these groups.
+# Note, we include all subdirs, including the vendor dir, as at present there are no .proto files
+# in the vendor dir. Later we may have to extend this matching rule if that changes.
+*.proto    @kata-containers/architecture-committee @kata-containers/builder @kata-containers/packaging
+


### PR DESCRIPTION
If a proto file is changed then we want a larger number of folks
to know about and review it. Add them to the CODEOWNERS file.

Fixes: #460

Signed-off-by: Graham Whaley <graham.whaley@intel.com>