### PR TITLE
agent: increase the number of tries to online vcpus

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -68,7 +68,7 @@ var emptyResp = &gpb.Empty{}
 
 const onlineCPUMemWaitTime = 100 * time.Millisecond
 
-const onlineCPUMaxTries = 10
+var onlineCPUMaxTries = uint32(100)
 
 const cpusetMode = 0644
 

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -227,6 +227,12 @@ func TestOnlineCPUMem(t *testing.T) {
 	sysfsCPUOnlinePath = "/xyz/123/rgb/abc"
 	sysfsMemOnlinePath = "/xyz/123/rgb/abc"
 
+	oldOnlineCPUMaxTries := onlineCPUMaxTries
+	onlineCPUMaxTries = 10
+	defer func() {
+		onlineCPUMaxTries = oldOnlineCPUMaxTries
+	}()
+
 	_, err := a.OnlineCPUMem(context.TODO(), req)
 	assert.Error(err, "sysfs paths do not exist")
 


### PR DESCRIPTION
cpu hotplug tests fail randomly in nested environments because 1 second is
not enough for the kernel and qemu to allocate and connect the vcpus.

fixes #474

Signed-off-by: Julio Montes <julio.montes@intel.com>