### PR TITLE
service: Fix user initiated shutdown

### DIFF
--- a/TRACING.md
+++ b/TRACING.md
@@ -51,7 +51,7 @@ forwards the information on to other components of a Jaeger system.
 
 The Jaeger client package bound into the application sends the trace spans to
 the Jaeger agent process using the UDP protocol. This is problematic since it
-is not desirable to run a `jaeger-agent` process inside the VM:
+is not desirable to run a `jaeger-agent` process inside the Virtual Machine (VM):
 
 - Adding extra binaries and an extra service to run the Jaeger agent inside
   the VM increases the size of the guest OS image used to

--- a/kata-agent.service.in
+++ b/kata-agent.service.in
@@ -16,4 +16,7 @@ StandardOutput=tty
 Type=simple
 ExecStart=@bindir@/@kata-agent@
 LimitNOFILE=infinity
-ExecStop=/bin/sync
+# ExecStop is required for static agent tracing; in all other scenarios
+# the runtime handles shutting down the VM.
+ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
+FailureAction=poweroff


### PR DESCRIPTION
Partially revert commit 272f273961e70096938ac7a3fe6477023c8f715a to stop a user-initiated shutdown (typing `exit` or control-d for example at a shall prompt) from hanging and leaving the hypervisor running.

Fixes #479.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>