### PR TITLE
lint: Switch golang linter to golangci-lint

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -459,7 +459,7 @@ func (s *sandbox) deleteContainer(id string) {
 }
 
 func (s *sandbox) getProcess(cid, execID string) (*process, *container, error) {
-	if s.running == false {
+	if !s.running {
 		return nil, nil, grpcStatus.Error(codes.FailedPrecondition, "Sandbox not started")
 	}
 
@@ -951,7 +951,7 @@ func makeUnaryInterceptor() grpc.UnaryServerInterceptor {
 
 		if !tracing {
 			// Just log call details
-			elapsed = time.Now().Sub(start)
+			elapsed = time.Since(start)
 			message = resp.(proto.Message)
 
 			logger := agentLog.WithFields(logrus.Fields{

--- a/channel.go
+++ b/channel.go
@@ -131,7 +131,7 @@ func (c *serialChannel) wait() error {
 	var events [1]unix.EpollEvent
 
 	fd := c.serialConn.Fd()
-	if fd <= 0 {
+	if fd == 0 {
 		return fmt.Errorf("serial port IO closed")
 	}
 
@@ -271,7 +271,7 @@ func findVirtualSerialPath(serialName string) (string, error) {
 			return "", err
 		}
 
-		if strings.Contains(string(content), serialName) == true {
+		if strings.Contains(string(content), serialName) {
 			return filepath.Join(devRootPath, port), nil
 		}
 	}

--- a/grpc.go
+++ b/grpc.go
@@ -190,7 +190,7 @@ func updateCpusetPath(cgroupPath string, newCpuset string, cookies cookie) error
 		cgroupParentPath = filepath.Join(cgroupParentPath, path)
 
 		// check if the cgroup was already updated.
-		if cookies[cgroupParentPath] == true {
+		if cookies[cgroupParentPath] {
 			agentLog.WithField("path", cgroupParentPath).Debug("cpuset cgroup already updated")
 			continue
 		}
@@ -373,7 +373,7 @@ func (a *agentGRPC) Version(ctx context.Context, req *pb.CheckRequest) (*pb.Vers
 }
 
 func (a *agentGRPC) getContainer(cid string) (*container, error) {
-	if a.sandbox.running == false {
+	if !a.sandbox.running {
 		return nil, grpcStatus.Error(codes.FailedPrecondition, "Sandbox not started")
 	}
 
@@ -793,7 +793,7 @@ func posixRlimitsToRlimits(posixRlimits []specs.POSIXRlimit) []configs.Rlimit {
 }
 
 func (a *agentGRPC) createContainerChecks(req *pb.CreateContainerRequest) (err error) {
-	if a.sandbox.running == false {
+	if !a.sandbox.running {
 		return grpcStatus.Error(codes.FailedPrecondition, "Sandbox not started, impossible to run a new container")
 	}
 
@@ -887,7 +887,7 @@ func (a *agentGRPC) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest)
 }
 
 func (a *agentGRPC) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*gpb.Empty, error) {
-	if a.sandbox.running == false {
+	if !a.sandbox.running {
 		return emptyResp, grpcStatus.Error(codes.FailedPrecondition, "Sandbox not started, impossible to signal the container")
 	}
 
@@ -1343,7 +1343,7 @@ func (a *agentGRPC) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeReques
 }
 
 func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*gpb.Empty, error) {
-	if a.sandbox.running == true {
+	if a.sandbox.running {
 		return emptyResp, grpcStatus.Error(codes.AlreadyExists, "Sandbox already started, impossible to start again")
 	}
 
@@ -1392,7 +1392,7 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 }
 
 func (a *agentGRPC) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*gpb.Empty, error) {
-	if a.sandbox.running == false {
+	if !a.sandbox.running {
 		agentLog.Info("Sandbox not started, this is a no-op")
 		return emptyResp, nil
 	}

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -741,11 +741,11 @@ func testAgentDetails(assert *assert.Assertions, details *pb.AgentDetails, haveS
 		storages = append(storages, handler)
 	}
 
-	sort.Sort(sort.StringSlice(details.DeviceHandlers))
-	sort.Sort(sort.StringSlice(details.StorageHandlers))
+	sort.Strings(details.DeviceHandlers)
+	sort.Strings(details.StorageHandlers)
 
-	sort.Sort(sort.StringSlice(devices))
-	sort.Sort(sort.StringSlice(storages))
+	sort.Strings(devices)
+	sort.Strings(storages)
 
 	assert.Equal(details.DeviceHandlers, devices)
 	assert.Equal(details.StorageHandlers, storages)

--- a/protocols/grpc/utils_test.go
+++ b/protocols/grpc/utils_test.go
@@ -73,8 +73,8 @@ func assertIsEqual(t *testing.T, ociSpec *specs.Spec, grpcSpec *Spec) {
 	assert.Equal(len(grpcSpec.Linux.Namespaces), 5)
 
 	for i := range grpcSpec.Linux.Namespaces {
-		assert.Equal(grpcSpec.Linux.Namespaces[i].Type, (string)(ociSpec.Linux.Namespaces[i].Type))
-		assert.Equal(grpcSpec.Linux.Namespaces[i].Path, (string)(ociSpec.Linux.Namespaces[i].Path))
+		assert.Equal(grpcSpec.Linux.Namespaces[i].Type, (string)(ociSpec.Linux.Namespaces[i].Type)) //nolint:unconvert
+		assert.Equal(grpcSpec.Linux.Namespaces[i].Path, (string)(ociSpec.Linux.Namespaces[i].Path)) //nolint:unconvert
 	}
 }
 


### PR DESCRIPTION
gometalinter is deprecated and will be archived April '19. The
suggestion is to switch to golangci-lint which is apparently 5x faster
than gometalinter.

Partially fixes: github.com/kata-containers/runtime#1377