### PR TITLE
agent: support read-only rootfs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -62,6 +62,7 @@ var initRootfsMounts = []initMount{
 	{"devtmpfs", "dev", "/dev", []string{"nosuid"}},
 	{"tmpfs", "tmpfs", "/dev/shm", []string{"nosuid", "nodev"}},
 	{"devpts", "devpts", "/dev/pts", []string{"nosuid", "noexec"}},
+	{"tmpfs", "tmpfs", "/run", []string{"nosuid", "nodev"}},
 }
 
 type process struct {


### PR DESCRIPTION
mount /run as a tmpfs to support read-only rootfs.

fixes #495

Signed-off-by: Julio Montes <julio.montes@intel.com>