### PR TITLE
make: Install systemd targets in systemd unit dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ TRACE_DEV_MODE := no
 # Path to systemd unit directory if installed as not init.
 UNIT_DIR := /usr/lib/systemd/system
 
+HAVE_SYSTEMD := $(shell pkg-config --exists systemd 2>/dev/null && echo 'yes')
+
+ifeq ($(HAVE_SYSTEMD),yes)
+	UNIT_DIR := $(shell pkg-config --variable=systemdsystemunitdir systemd)
+endif
+
 # Path to systemd drop-in snippet directory used to override the agent's
 # service without having to modify the pristine agent service file.
 SNIPPET_DIR := /etc/systemd/system/$(AGENT_SERVICE).d/


### PR DESCRIPTION
Install the agent systemd targets after evaluating the systemd
unitdir configured for the systemd package.
We were initially assuming this as "/usr/lib/systemd/system/"
but this is not the case for all distros such as debian and ubuntu.

Fixes #498

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>