### PR TITLE
systemd-target: Add chronyd.service to kata-containers.target

### DIFF
--- a/kata-containers.target
+++ b/kata-containers.target
@@ -1,6 +1,13 @@
+#
+# Copyright (c) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 [Unit]
 Description=Kata Containers Agent Target
 Requires=basic.target
+Wants=chronyd.service
 Requires=kata-agent.service
 Conflicts=rescue.service rescue.target
 After=basic.target rescue.service rescue.target


### PR DESCRIPTION
Add chronyd service so that it is started with kata-containers.target.

Fixes #500

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>