### PR TITLE
agent: Display trace details

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -206,11 +206,11 @@ func TestParseCmdlineOptionTracing(t *testing.T) {
 		{traceModeFlag + "=", false, false},
 
 		{traceModeFlag, true, false},
-		{traceModeFlag + "=" + traceValueIsolated, true, false},
-		{traceModeFlag + "=" + traceValueCollated, true, true},
+		{traceModeFlag + "=" + traceTypeIsolated, true, false},
+		{traceModeFlag + "=" + traceTypeCollated, true, true},
 
-		{traceModeFlag + "=" + traceValueIsolated + "x", false, false},
-		{traceModeFlag + "=" + traceValueCollated + "x", false, false},
+		{traceModeFlag + "=" + traceTypeIsolated + "x", false, false},
+		{traceModeFlag + "=" + traceTypeCollated + "x", false, false},
 	}
 
 	for i, d := range data {
@@ -259,12 +259,17 @@ func TestEnableTracing(t *testing.T) {
 	assert := assert.New(t)
 
 	type testData struct {
-		collatedTrace bool
+		traceMode           string
+		traceType           string
+		expectCollatedTrace bool
 	}
 
 	data := []testData{
-		{false},
-		{true},
+		{traceModeStatic, traceTypeIsolated, false},
+		{traceModeStatic, traceTypeCollated, true},
+
+		{traceModeDynamic, traceTypeIsolated, false},
+		{traceModeDynamic, traceTypeCollated, true},
 	}
 
 	for i, d := range data {
@@ -273,12 +278,12 @@ func TestEnableTracing(t *testing.T) {
 		collatedTrace = false
 		debug = false
 
-		enableTracing(d.collatedTrace)
+		enableTracing(d.traceMode, d.traceType)
 
 		assert.True(debug, "test %d (%+v)", i, d)
 		assert.True(tracing, "test %d (%+v)", i, d)
 
-		if d.collatedTrace {
+		if d.expectCollatedTrace {
 			assert.True(collatedTrace, "test %d (%+v)", i, d)
 		} else {
 			assert.False(collatedTrace, "test %d (%+v)", i, d)

--- a/grpc.go
+++ b/grpc.go
@@ -1689,7 +1689,8 @@ func (a *agentGRPC) StartTracing(ctx context.Context, req *pb.StartTracingReques
 		return nil, grpcStatus.Error(codes.FailedPrecondition, "tracing already enabled")
 	}
 
-	enableTracing(false)
+	// The only trace type support for dynamic tracing is isolated.
+	enableTracing(traceModeDynamic, traceTypeIsolated)
 	startTracingCalled = true
 
 	var err error


### PR DESCRIPTION
Log the trace mode and type when tracing is enabled. The change makes it clearer that static tracing is enabled when the agent parsers the kernel command line (`config.go`) and dynamic tracing is enabled by gRPC (`grpc.go`).

Specifics of change:

- Rename variables to match the terms defined in `TRACING.md`.
- Pass trace mode and trace type arguments to `enableTracing()`.
- Change the tense of the message displayed by `enableTracing()` so that the message indicates that tracing *is* enabled, not *about to be*.

Fixes #504.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>