### PR TITLE
vendor: use latest github.com/mdlayher/vsock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -118,11 +118,11 @@
   revision = "cc6d2ea263b2471faabce371255777a365bf8306"
 
 [[projects]]
-  digest = "1:f3e11773cc8a305f97b42c276f62d92899c9b0c1c3c584a667149b18f18a530a"
+  digest = "1:79062b1e6d284b7a41cf04ba20f5dbc371a4fdd5edaca748ddb827ab07846dbf"
   name = "github.com/mdlayher/vsock"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "676f733b747cd6406f297a51bd086ee8ec8abdbe"
+  revision = "a92c53d5dcabbf6aaaba8fe07983d4f10f812fa7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/mdlayher/vsock"
-  revision = "676f733b747cd6406f297a51bd086ee8ec8abdbe"
+  revision = "a92c53d5dcabbf6aaaba8fe07983d4f10f812fa7"
 
 [[constraint]]
   name = "github.com/opencontainers/runc"

--- a/vendor/github.com/mdlayher/vsock/conn_linux.go
+++ b/vendor/github.com/mdlayher/vsock/conn_linux.go
@@ -3,75 +3,45 @@
 package vsock
 
 import (
-	"net"
-	"os"
-	"time"
-
 	"golang.org/x/sys/unix"
 )
 
-var _ net.Conn = &conn{}
-
-// A conn is the net.Conn implementation for VM sockets.
-type conn struct {
-	file       *os.File
-	localAddr  *Addr
-	remoteAddr *Addr
-}
-
-// Implement net.Conn for type conn.
-func (c *conn) LocalAddr() net.Addr                { return c.localAddr }
-func (c *conn) RemoteAddr() net.Addr               { return c.remoteAddr }
-func (c *conn) SetDeadline(t time.Time) error      { return c.file.SetDeadline(t) }
-func (c *conn) SetReadDeadline(t time.Time) error  { return c.file.SetReadDeadline(t) }
-func (c *conn) SetWriteDeadline(t time.Time) error { return c.file.SetWriteDeadline(t) }
-func (c *conn) Read(b []byte) (n int, err error)   { return c.file.Read(b) }
-func (c *conn) Write(b []byte) (n int, err error)  { return c.file.Write(b) }
-func (c *conn) Close() error                       { return c.file.Close() }
-
-// newConn creates a conn using an fd with the specified file name, local, and
-// remote addresses.
-func newConn(cfd fd, file string, local, remote *Addr) (*conn, error) {
-	// Enable integration with runtime network poller for timeout support
-	// in Go 1.11+.
-	if err := cfd.SetNonblock(true); err != nil {
+// newConn creates a Conn using a connFD, immediately setting the connFD to
+// non-blocking mode for use with the runtime network poller.
+func newConn(cfd connFD, local, remote *Addr) (*Conn, error) {
+	// Note: if any calls fail after this point, cfd.Close should be invoked
+	// for cleanup because the socket is now non-blocking.
+	if err := cfd.SetNonblocking(local.fileName()); err != nil {
 		return nil, err
 	}
 
-	return &conn{
-		file:       cfd.NewFile(file),
-		localAddr:  local,
-		remoteAddr: remote,
+	return &Conn{
+		fd:     cfd,
+		local:  local,
+		remote: remote,
 	}, nil
 }
 
-// dialStream is the entry point for DialStream on Linux.
-func dialStream(cid, port uint32) (net.Conn, error) {
-	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+// dial is the entry point for Dial on Linux.
+func dial(cid, port uint32) (*Conn, error) {
+	cfd, err := newConnFD()
 	if err != nil {
 		return nil, err
 	}
 
-	cfd := &sysFD{fd: fd}
-	return dialStreamLinuxHandleError(cfd, cid, port)
+	return dialLinux(cfd, cid, port)
 }
 
-// dialStreamLinuxHandleError ensures that any errors from dialStreamLinux result
-// in the socket being cleaned up properly.
-func dialStreamLinuxHandleError(cfd fd, cid, port uint32) (net.Conn, error) {
-	c, err := dialStreamLinux(cfd, cid, port)
-	if err != nil {
-		// If any system calls fail during setup, the socket must be closed
-		// to avoid file descriptor leaks.
-		_ = cfd.Close()
-		return nil, err
-	}
+// dialLinux is the entry point for tests on Linux.
+func dialLinux(cfd connFD, cid, port uint32) (c *Conn, err error) {
+	defer func() {
+		if err != nil {
+			// If any system calls fail during setup, the socket must be closed
+			// to avoid file descriptor leaks.
+			_ = cfd.EarlyClose()
+		}
+	}()
 
-	return c, nil
-}
-
-// dialStreamLinux is the entry point for tests on Linux.
-func dialStreamLinux(cfd fd, cid, port uint32) (net.Conn, error) {
 	rsa := &unix.SockaddrVM{
 		CID:  cid,
 		Port: port,
@@ -87,16 +57,16 @@ func dialStreamLinux(cfd fd, cid, port uint32) (net.Conn, error) {
 	}
 
 	lsavm := lsa.(*unix.SockaddrVM)
-	localAddr := &Addr{
+
+	local := &Addr{
 		ContextID: lsavm.CID,
 		Port:      lsavm.Port,
 	}
 
-	remoteAddr := &Addr{
+	remote := &Addr{
 		ContextID: cid,
 		Port:      port,
 	}
 
-	// File name is the name of the local socket.
-	return newConn(cfd, localAddr.fileName(), localAddr, remoteAddr)
+	return newConn(cfd, local, remote)
 }

--- a/vendor/github.com/mdlayher/vsock/doc.go
+++ b/vendor/github.com/mdlayher/vsock/doc.go
@@ -1,0 +1,53 @@
+// Package vsock provides access to Linux VM sockets (AF_VSOCK) for
+// communication between a hypervisor and its virtual machines.
+//
+// The types in this package implement interfaces provided by package net and
+// may be used in applications that expect a net.Listener or net.Conn.
+//
+//   - *Addr implements net.Addr
+//   - *Conn implements net.Conn
+//   - *Listener implements net.Listener
+//
+// Go version support
+//
+// This package supports varying levels of functionality depending on the version
+// of Go used during compilation. The Listener and Conn types produced by this
+// package are backed by non-blocking I/O, in order to integrate with Go's
+// runtime network poller in Go 1.11+. Additional functionality is available
+// starting in Go 1.12+.
+//
+// Go 1.12+ (recommended):
+//   - *Listener:
+//     - Accept blocks until a connection is received
+//     - Close can interrupt Accept and make it return a permanent error
+//     - SetDeadline can set timeouts which can interrupt Accept and make it return a
+//       temporary error
+//   - *Conn:
+//     - SetDeadline family of methods are fully supported
+//     - CloseRead and CloseWrite can close the reading or writing sides of a
+//       Conn, respectively
+//     - SyscallConn provides access to raw network control/read/write functionality
+//
+// Go 1.11 (not recommended):
+//   - *Listener:
+//     - Accept is non-blocking and should be called in a loop, checking for
+//       net.Error.Temporary() == true and sleeping for a short period to avoid wasteful
+//       CPU cycle consumption
+//     - Close makes Accept return a permanent error on the next loop iteration
+//     - SetDeadline is not supported and will always return an error
+//   - *Conn:
+//     - SetDeadline family of methods are fully supported
+//     - CloseRead and CloseWrite are not supported and will always return an error
+//     - SyscallConn is not supported and will always return an error
+//
+// Go 1.10 and below are not supported. The runtime network poller integration
+// required by this package is not available in Go versions prior to Go 1.11.
+//
+// Stability
+//
+// At this time, package vsock is in a pre-v1.0.0 state. Changes are being made
+// which may impact the exported API of this package and others in its ecosystem.
+//
+// If you depend on this package in your application, please use Go modules when
+// building your application.
+package vsock

--- a/vendor/github.com/mdlayher/vsock/fd_linux.go
+++ b/vendor/github.com/mdlayher/vsock/fd_linux.go
@@ -1,45 +1,202 @@
 package vsock
 
 import (
+	"fmt"
+	"io"
 	"os"
+	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-// A fd is an interface for a file descriptor, used to perform system
-// calls or swap them out for tests.
-type fd interface {
-	Accept4(flags int) (fd, unix.Sockaddr, error)
+// A listenFD is a type that wraps a file descriptor used to implement
+// net.Listener.
+type listenFD interface {
+	io.Closer
+	EarlyClose() error
+	Accept4(flags int) (connFD, unix.Sockaddr, error)
 	Bind(sa unix.Sockaddr) error
-	Close() error
-	Connect(sa unix.Sockaddr) error
-	Getsockname() (unix.Sockaddr, error)
 	Listen(n int) error
-	NewFile(name string) *os.File
-	SetNonblock(nonblocking bool) error
+	Getsockname() (unix.Sockaddr, error)
+	SetNonblocking(name string) error
+	SetDeadline(t time.Time) error
 }
 
-var _ fd = &sysFD{}
+var _ listenFD = &sysListenFD{}
 
-// sysFD is the system call implementation of fd.
-type sysFD struct {
-	fd int
+// A sysListenFD is the system call implementation of listenFD.
+type sysListenFD struct {
+	// These fields should never be non-zero at the same time.
+	fd int      // Used in blocking mode.
+	f  *os.File // Used in non-blocking mode.
 }
 
-func (fd *sysFD) Accept4(flags int) (fd, unix.Sockaddr, error) {
-	// Returns a regular file descriptor, must be wrapped in another
-	// sysFD for it to work properly.
-	nfd, sa, err := unix.Accept4(fd.fd, flags)
+// newListenFD creates a sysListenFD in its default blocking mode.
+func newListenFD() (*sysListenFD, error) {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sysListenFD{
+		fd: fd,
+	}, nil
+}
+
+// Blocking mode methods.
+
+func (lfd *sysListenFD) Bind(sa unix.Sockaddr) error         { return unix.Bind(lfd.fd, sa) }
+func (lfd *sysListenFD) Getsockname() (unix.Sockaddr, error) { return unix.Getsockname(lfd.fd) }
+func (lfd *sysListenFD) Listen(n int) error                  { return unix.Listen(lfd.fd, n) }
+
+func (lfd *sysListenFD) SetNonblocking(name string) error {
+	// From now on, we must perform non-blocking I/O, so that our
+	// net.Listener.Accept method can be interrupted by closing the socket.
+	if err := unix.SetNonblock(lfd.fd, true); err != nil {
+		return err
+	}
+
+	// Transition from blocking mode to non-blocking mode.
+	lfd.f = os.NewFile(uintptr(lfd.fd), name)
+
+	return nil
+}
+
+// EarlyClose is a blocking version of Close, only used for cleanup before
+// entering non-blocking mode.
+func (lfd *sysListenFD) EarlyClose() error { return unix.Close(lfd.fd) }
+
+// Non-blocking mode methods.
+
+func (lfd *sysListenFD) Accept4(flags int) (connFD, unix.Sockaddr, error) {
+	// Invoke Go version-specific logic for accept.
+	newFD, sa, err := lfd.accept4(flags)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return &sysFD{fd: nfd}, sa, nil
+	// Create a non-blocking connFD which will be used to implement net.Conn.
+	cfd := &sysConnFD{fd: newFD}
+	return cfd, sa, nil
 }
-func (fd *sysFD) Bind(sa unix.Sockaddr) error         { return unix.Bind(fd.fd, sa) }
-func (fd *sysFD) Close() error                        { return unix.Close(fd.fd) }
-func (fd *sysFD) Connect(sa unix.Sockaddr) error      { return unix.Connect(fd.fd, sa) }
-func (fd *sysFD) Getsockname() (unix.Sockaddr, error) { return unix.Getsockname(fd.fd) }
-func (fd *sysFD) Listen(n int) error                  { return unix.Listen(fd.fd, n) }
-func (fd *sysFD) NewFile(name string) *os.File        { return os.NewFile(uintptr(fd.fd), name) }
-func (fd *sysFD) SetNonblock(nonblocking bool) error  { return unix.SetNonblock(fd.fd, nonblocking) }
+
+func (lfd *sysListenFD) Close() error {
+	// In Go 1.12+, *os.File.Close will also close the runtime network poller
+	// file descriptor, so that net.Listener.Accept can stop blocking.
+	return lfd.f.Close()
+}
+
+func (lfd *sysListenFD) SetDeadline(t time.Time) error {
+	// Invoke Go version-specific logic for setDeadline.
+	return lfd.setDeadline(t)
+}
+
+// A connFD is a type that wraps a file descriptor used to implement net.Conn.
+type connFD interface {
+	io.ReadWriteCloser
+	EarlyClose() error
+	Connect(sa unix.Sockaddr) error
+	Getsockname() (unix.Sockaddr, error)
+	Shutdown(how int) error
+	SetNonblocking(name string) error
+	SetDeadline(t time.Time, typ deadlineType) error
+	SyscallConn() (syscall.RawConn, error)
+}
+
+var _ connFD = &sysConnFD{}
+
+// newConnFD creates a sysConnFD in its default blocking mode.
+func newConnFD() (*sysConnFD, error) {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sysConnFD{
+		fd: fd,
+	}, nil
+}
+
+// A sysConnFD is the system call implementation of connFD.
+type sysConnFD struct {
+	// These fields should never be non-zero at the same time.
+	fd int      // Used in blocking mode.
+	f  *os.File // Used in non-blocking mode.
+}
+
+// Blocking mode methods.
+
+func (cfd *sysConnFD) Connect(sa unix.Sockaddr) error      { return unix.Connect(cfd.fd, sa) }
+func (cfd *sysConnFD) Getsockname() (unix.Sockaddr, error) { return unix.Getsockname(cfd.fd) }
+
+// EarlyClose is a blocking version of Close, only used for cleanup before
+// entering non-blocking mode.
+func (cfd *sysConnFD) EarlyClose() error { return unix.Close(cfd.fd) }
+
+func (cfd *sysConnFD) SetNonblocking(name string) error {
+	// From now on, we must perform non-blocking I/O, so that our deadline
+	// methods work, and the connection can be interrupted by net.Conn.Close.
+	if err := unix.SetNonblock(cfd.fd, true); err != nil {
+		return err
+	}
+
+	// Transition from blocking mode to non-blocking mode.
+	cfd.f = os.NewFile(uintptr(cfd.fd), name)
+
+	return nil
+}
+
+// Non-blocking mode methods.
+
+func (cfd *sysConnFD) Close() error {
+	// *os.File.Close will also close the runtime network poller file descriptor,
+	// so that read/write can stop blocking.
+	return cfd.f.Close()
+}
+
+func (cfd *sysConnFD) Read(b []byte) (int, error)  { return cfd.f.Read(b) }
+func (cfd *sysConnFD) Write(b []byte) (int, error) { return cfd.f.Write(b) }
+
+func (cfd *sysConnFD) Shutdown(how int) error {
+	switch how {
+	case unix.SHUT_RD, unix.SHUT_WR:
+		return cfd.shutdown(how)
+	default:
+		panicf("vsock: sysConnFD.Shutdown method invoked with invalid how constant: %d", how)
+		return nil
+	}
+}
+
+func (cfd *sysConnFD) SetDeadline(t time.Time, typ deadlineType) error {
+	switch typ {
+	case deadline:
+		return cfd.f.SetDeadline(t)
+	case readDeadline:
+		return cfd.f.SetReadDeadline(t)
+	case writeDeadline:
+		return cfd.f.SetWriteDeadline(t)
+	default:
+		panicf("vsock: sysConnFD.SetDeadline method invoked with invalid deadline type constant: %d", typ)
+		return nil
+	}
+}
+
+func (cfd *sysConnFD) SyscallConn() (syscall.RawConn, error) { return cfd.syscallConn() }
+
+// isErrno determines if an error a matches UNIX error number.
+func isErrno(err error, errno int) bool {
+	switch errno {
+	case ebadf:
+		return err == unix.EBADF
+	case enotconn:
+		return err == unix.ENOTCONN
+	default:
+		panicf("vsock: isErrno called with unhandled error number parameter: %d", errno)
+		return false
+	}
+}
+
+func panicf(format string, a ...interface{}) {
+	panic(fmt.Sprintf(format, a...))
+}

--- a/vendor/github.com/mdlayher/vsock/fd_linux_gteq_1.12.go
+++ b/vendor/github.com/mdlayher/vsock/fd_linux_gteq_1.12.go
@@ -1,0 +1,71 @@
+//+build go1.12,linux
+
+package vsock
+
+import (
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
+	// In Go 1.12+, we make use of runtime network poller integration to allow
+	// net.Listener.Accept to be unblocked by a call to net.Listener.Close.
+	rc, err := lfd.f.SyscallConn()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var (
+		newFD int
+		sa    unix.Sockaddr
+	)
+
+	doErr := rc.Read(func(fd uintptr) bool {
+		newFD, sa, err = unix.Accept4(int(fd), flags)
+
+		switch err {
+		case unix.EAGAIN, unix.ECONNABORTED:
+			// Return false to let the poller wait for readiness. See the
+			// source code for internal/poll.FD.RawRead for more details.
+			//
+			// When the socket is in non-blocking mode, we might see EAGAIN if
+			// the socket is not ready for reading.
+			//
+			// In addition, the network poller's accept implementation also
+			// deals with ECONNABORTED, in case a socket is closed before it is
+			// pulled from our listen queue.
+			return false
+		default:
+			// No error or some unrecognized error, treat this Read operation
+			// as completed.
+			return true
+		}
+	})
+	if doErr != nil {
+		return 0, nil, doErr
+	}
+
+	return newFD, sa, err
+}
+
+func (lfd *sysListenFD) setDeadline(t time.Time) error { return lfd.f.SetDeadline(t) }
+
+func (cfd *sysConnFD) shutdown(how int) error {
+	rc, err := cfd.f.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	doErr := rc.Control(func(fd uintptr) {
+		err = unix.Shutdown(int(fd), how)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+func (cfd *sysConnFD) syscallConn() (syscall.RawConn, error) { return cfd.f.SyscallConn() }

--- a/vendor/github.com/mdlayher/vsock/fd_linux_lt_1.12.go
+++ b/vendor/github.com/mdlayher/vsock/fd_linux_lt_1.12.go
@@ -1,0 +1,35 @@
+//+build !go1.12,linux
+
+package vsock
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
+	// In Go 1.11, accept on the raw file descriptor directly, because lfd.f
+	// may be attached to the runtime network poller, forcing this call to block
+	// even if Close is called.
+	return unix.Accept4(lfd.fd, flags)
+}
+
+func (*sysListenFD) setDeadline(_ time.Time) error {
+	// Listener deadlines won't work as expected in this version of Go, so
+	// return an early error.
+	return fmt.Errorf("vsock: listener deadlines not supported on %s", runtime.Version())
+}
+
+func (*sysConnFD) shutdown(_ int) error {
+	// Shutdown functionality is not available in this version on Go.
+	return fmt.Errorf("vsock: close conn read/write not supported on %s", runtime.Version())
+}
+
+func (*sysConnFD) syscallConn() (syscall.RawConn, error) {
+	// SyscallConn functionality is not available in this version on Go.
+	return nil, fmt.Errorf("vsock: syscall conn not supported on %s", runtime.Version())
+}

--- a/vendor/github.com/mdlayher/vsock/vsock.go
+++ b/vendor/github.com/mdlayher/vsock/vsock.go
@@ -1,37 +1,128 @@
-// Package vsock provides access to Linux VM sockets (AF_VSOCK) for
-// communication between a hypervisor and its virtual machines.
 package vsock
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
 )
 
 const (
-	// ContextIDHypervisor specifies that a socket should communicate with
-	// the hypervisor process.
-	ContextIDHypervisor uint32 = 0x0
+	// Hypervisor specifies that a socket should communicate with the hypervisor
+	// process.
+	Hypervisor = 0x0
 
-	// ContextIDReserved is a reserved context ID that is no longer in use,
+	// Host specifies that a socket should communicate with processes other than
+	// the hypervisor on the host machine.
+	Host = 0x2
+
+	// cidReserved is a reserved context ID that is no longer in use,
 	// and cannot be used for socket communications.
-	ContextIDReserved uint32 = 0x1
+	cidReserved = 0x1
 
-	// ContextIDHost specifies that a socket should communicate with other
-	// processes than the hypervisor on the host machine.
-	ContextIDHost uint32 = 0x2
+	// shutRd and shutWr are arguments for unix.Shutdown, copied here to avoid
+	// importing x/sys/unix in cross-platform code.
+	shutRd = 0 // unix.SHUT_RD
+	shutWr = 1 // unix.SHUT_WR
+
+	// Error numbers we recognize, copied here to avoid importing x/sys/unix in
+	// cross-platform code.
+	ebadf    = 9
+	enotconn = 107
+
+	// devVsock is the location of /dev/vsock.  It is exposed on both the
+	// hypervisor and on virtual machines.
+	devVsock = "/dev/vsock"
+
+	// network is the vsock network reported in net.OpError.
+	network = "vsock"
+
+	// Operation names which may be returned in net.OpError.
+	opAccept      = "accept"
+	opClose       = "close"
+	opDial        = "dial"
+	opListen      = "listen"
+	opRawControl  = "raw-control"
+	opRawRead     = "raw-read"
+	opRawWrite    = "raw-write"
+	opRead        = "read"
+	opSet         = "set"
+	opSyscallConn = "syscall-conn"
+	opWrite       = "write"
 )
 
 // Listen opens a connection-oriented net.Listener for incoming VM sockets
-// connections.  The port parameter specifies the port for the listener.
+// connections. The port parameter specifies the port for the Listener.
 //
 // To allow the server to assign a port automatically, specify 0 for port.
 // The address of the server can be retrieved using the Addr method.
 //
-// The Accept method is used to accept incoming connections.
+// When the Listener is no longer needed, Close must be called to free resources.
+func Listen(port uint32) (*Listener, error) {
+	cid, err := ContextID()
+	if err != nil {
+		// No addresses available.
+		return nil, opError(opListen, err, nil, nil)
+	}
+
+	l, err := listen(cid, port)
+	if err != nil {
+		// No remote address available.
+		return nil, opError(opListen, err, &Addr{
+			ContextID: cid,
+			Port:      port,
+		}, nil)
+	}
+
+	return l, nil
+}
+
+var _ net.Listener = &Listener{}
+
+// A Listener is a VM sockets implementation of a net.Listener.
+type Listener struct {
+	l *listener
+}
+
+// Accept implements the Accept method in the net.Listener interface; it waits
+// for the next call and returns a generic net.Conn. The returned net.Conn will
+// always be of type *Conn.
+func (l *Listener) Accept() (net.Conn, error) {
+	c, err := l.l.Accept()
+	if err != nil {
+		return nil, l.opError(opAccept, err)
+	}
+
+	return c, nil
+}
+
+// Addr returns the listener's network address, a *Addr. The Addr returned is
+// shared by all invocations of Addr, so do not modify it.
+func (l *Listener) Addr() net.Addr { return l.l.Addr() }
+
+// Close stops listening on the VM sockets address. Already Accepted connections
+// are not closed.
+func (l *Listener) Close() error {
+	return l.opError(opClose, l.l.Close())
+}
+
+// SetDeadline sets the deadline associated with the listener. A zero time value
+// disables the deadline.
 //
-// When the listener is no longer needed, Close must be called to free resources.
-func Listen(port uint32) (net.Listener, error) {
-	return listenStream(port)
+// SetDeadline only works with Go 1.12+.
+func (l *Listener) SetDeadline(t time.Time) error {
+	return l.opError(opSet, l.l.SetDeadline(t))
+}
+
+// opError is a convenience for the function opError that also passes the local
+// address of the Listener.
+func (l *Listener) opError(op string, err error) error {
+	// No remote address for a Listener.
+	return opError(op, err, l.Addr(), nil)
 }
 
 // Dial dials a connection-oriented net.Conn to a VM sockets server.
@@ -40,16 +131,159 @@ func Listen(port uint32) (net.Listener, error) {
 // If dialing a connection from the hypervisor to a virtual machine, the VM's
 // context ID should be specified.
 //
-// If dialing from a VM to the hypervisor, ContextIDHypervisor should be used
-// to talk to the hypervisor process, or ContextIDHost should be used to talk
-// to other processes on the host machine.
+// If dialing from a VM to the hypervisor, Hypervisor should be used to
+// communicate with the hypervisor process, or Host should be used to
+// communicate with other processes on the host machine.
 //
 // When the connection is no longer needed, Close must be called to free resources.
-func Dial(contextID, port uint32) (net.Conn, error) {
-	return dialStream(contextID, port)
+func Dial(contextID, port uint32) (*Conn, error) {
+	c, err := dial(contextID, port)
+	if err != nil {
+		// No local address, but we have a remote address we can return.
+		return nil, opError(opDial, err, nil, &Addr{
+			ContextID: contextID,
+			Port:      port,
+		})
+	}
+
+	return c, nil
 }
 
-// TODO(mdlayher): ListenPacket and DialPacket (or maybe another parameter for Dial?).
+var _ net.Conn = &Conn{}
+var _ syscall.Conn = &Conn{}
+
+// A Conn is a VM sockets implementation of a net.Conn.
+type Conn struct {
+	fd     connFD
+	local  *Addr
+	remote *Addr
+}
+
+// Close closes the connection.
+func (c *Conn) Close() error {
+	return c.opError(opClose, c.fd.Close())
+}
+
+// CloseRead shuts down the reading side of the VM sockets connection. Most
+// callers should just use Close.
+//
+// CloseRead only works with Go 1.12+.
+func (c *Conn) CloseRead() error {
+	return c.opError(opClose, c.fd.Shutdown(shutRd))
+}
+
+// CloseWrite shuts down the writing side of the VM sockets connection. Most
+// callers should just use Close.
+//
+// CloseWrite only works with Go 1.12+.
+func (c *Conn) CloseWrite() error {
+	return c.opError(opClose, c.fd.Shutdown(shutWr))
+}
+
+// LocalAddr returns the local network address. The Addr returned is shared by
+// all invocations of LocalAddr, so do not modify it.
+func (c *Conn) LocalAddr() net.Addr { return c.local }
+
+// RemoteAddr returns the remote network address. The Addr returned is shared by
+// all invocations of RemoteAddr, so do not modify it.
+func (c *Conn) RemoteAddr() net.Addr { return c.remote }
+
+// Read implements the net.Conn Read method.
+func (c *Conn) Read(b []byte) (int, error) {
+	n, err := c.fd.Read(b)
+	if err != nil {
+		return n, c.opError(opRead, err)
+	}
+
+	return n, nil
+}
+
+// Write implements the net.Conn Write method.
+func (c *Conn) Write(b []byte) (int, error) {
+	n, err := c.fd.Write(b)
+	if err != nil {
+		return n, c.opError(opWrite, err)
+	}
+
+	return n, nil
+}
+
+// A deadlineType specifies the type of deadline to set for a Conn.
+type deadlineType int
+
+// Possible deadlineType values.
+const (
+	deadline deadlineType = iota
+	readDeadline
+	writeDeadline
+)
+
+// SetDeadline implements the net.Conn SetDeadline method.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.opError(opSet, c.fd.SetDeadline(t, deadline))
+}
+
+// SetReadDeadline implements the net.Conn SetReadDeadline method.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.opError(opSet, c.fd.SetDeadline(t, readDeadline))
+}
+
+// SetWriteDeadline implements the net.Conn SetWriteDeadline method.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.opError(opSet, c.fd.SetDeadline(t, writeDeadline))
+}
+
+// SyscallConn returns a raw network connection. This implements the
+// syscall.Conn interface.
+func (c *Conn) SyscallConn() (syscall.RawConn, error) {
+	rc, err := c.fd.SyscallConn()
+	if err != nil {
+		return nil, c.opError(opSyscallConn, err)
+	}
+
+	return &rawConn{
+		rc:     rc,
+		local:  c.local,
+		remote: c.remote,
+	}, nil
+}
+
+// opError is a convenience for the function opError that also passes the local
+// and remote addresses of the Conn.
+func (c *Conn) opError(op string, err error) error {
+	return opError(op, err, c.local, c.remote)
+}
+
+var _ syscall.RawConn = &rawConn{}
+
+// A rawConn is a syscall.RawConn that wraps an internal syscall.RawConn in order
+// to produce net.OpError error values.
+type rawConn struct {
+	rc     syscall.RawConn
+	local  *Addr
+	remote *Addr
+}
+
+// Control implements the syscall.RawConn Control method.
+func (rc *rawConn) Control(fn func(fd uintptr)) error {
+	return rc.opError(opRawControl, rc.rc.Control(fn))
+}
+
+// Control implements the syscall.RawConn Read method.
+func (rc *rawConn) Read(fn func(fd uintptr) (done bool)) error {
+	return rc.opError(opRawRead, rc.rc.Read(fn))
+}
+
+// Control implements the syscall.RawConn Write method.
+func (rc *rawConn) Write(fn func(fd uintptr) (done bool)) error {
+	return rc.opError(opRawWrite, rc.rc.Write(fn))
+}
+
+// opError is a convenience for the function opError that also passes the local
+// and remote addresses of the rawConn.
+func (rc *rawConn) opError(op string, err error) error {
+	return opError(op, err, rc.local, rc.remote)
+}
 
 var _ net.Addr = &Addr{}
 
@@ -60,7 +294,7 @@ type Addr struct {
 }
 
 // Network returns the address's network name, "vsock".
-func (a *Addr) Network() string { return "vsock" }
+func (a *Addr) Network() string { return network }
 
 // String returns a human-readable representation of Addr, and indicates if
 // ContextID is meant to be used for a hypervisor, host, VM, etc.
@@ -68,11 +302,11 @@ func (a *Addr) String() string {
 	var host string
 
 	switch a.ContextID {
-	case ContextIDHypervisor:
+	case Hypervisor:
 		host = fmt.Sprintf("hypervisor(%d)", a.ContextID)
-	case ContextIDReserved:
+	case cidReserved:
 		host = fmt.Sprintf("reserved(%d)", a.ContextID)
-	case ContextIDHost:
+	case Host:
 		host = fmt.Sprintf("host(%d)", a.ContextID)
 	default:
 		host = fmt.Sprintf("vm(%d)", a.ContextID)
@@ -84,4 +318,82 @@ func (a *Addr) String() string {
 // fileName returns a file name for use with os.NewFile for Addr.
 func (a *Addr) fileName() string {
 	return fmt.Sprintf("%s:%s", a.Network(), a.String())
+}
+
+// ContextID retrieves the local VM sockets context ID for this system.
+// ContextID can be used to directly determine if a system is capable of using
+// VM sockets.
+//
+// If the kernel module is unavailable, access to the kernel module is denied,
+// or VM sockets are unsupported on this system, it returns an error.
+func ContextID() (uint32, error) {
+	return contextID()
+}
+
+// opError unpacks err if possible, producing a net.OpError with the input
+// parameters in order to implement net.Conn. As a convenience, opError returns
+// nil if the input error is nil.
+func opError(op string, err error, local, remote net.Addr) error {
+	if err == nil {
+		return nil
+	}
+
+	// Unwrap inner errors from error types.
+	//
+	// TODO(mdlayher): errors.Cause or similar in Go 1.13.
+	switch xerr := err.(type) {
+	// os.PathError produced by os.File method calls.
+	case *os.PathError:
+		// Although we could make use of xerr.Op here, we're passing it manually
+		// for consistency, since some of the Conn calls we are making don't
+		// wrap an os.File, which would return an Op for us.
+		//
+		// As a special case, if the error is related to access to the /dev/vsock
+		// device, we don't unwrap it, so the caller has more context as to why
+		// their operation actually failed than "permission denied" or similar.
+		if xerr.Path != devVsock {
+			err = xerr.Err
+		}
+	}
+
+	switch {
+	case err == io.EOF, isErrno(err, enotconn):
+		// We may see a literal io.EOF as happens with x/net/nettest, but
+		// "transport not connected" also means io.EOF in Go.
+		return io.EOF
+	case err == os.ErrClosed, isErrno(err, ebadf), strings.Contains(err.Error(), "use of closed"):
+		// Different operations may return different errors that all effectively
+		// indicate a closed file.
+		//
+		// To rectify the differences, net.TCPConn uses an error with this text
+		// from internal/poll for the backing file already being closed.
+		err = errors.New("use of closed network connection")
+	default:
+		// Nothing to do, return this directly.
+	}
+
+	// Determine source and addr using the rules defined by net.OpError's
+	// documentation: https://golang.org/pkg/net/#OpError.
+	var source, addr net.Addr
+	switch op {
+	case opClose, opDial, opRawRead, opRawWrite, opRead, opWrite:
+		if local != nil {
+			source = local
+		}
+		if remote != nil {
+			addr = remote
+		}
+	case opAccept, opListen, opRawControl, opSet, opSyscallConn:
+		if local != nil {
+			addr = local
+		}
+	}
+
+	return &net.OpError{
+		Op:     op,
+		Net:    network,
+		Source: source,
+		Addr:   addr,
+		Err:    err,
+	}
 }

--- a/vendor/github.com/mdlayher/vsock/vsock_others.go
+++ b/vendor/github.com/mdlayher/vsock/vsock_others.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"syscall"
+	"time"
 )
 
 var (
@@ -15,10 +17,28 @@ var (
 		runtime.GOOS, runtime.GOARCH)
 )
 
-func listenStream(_ uint32) (net.Listener, error) {
-	return nil, errUnimplemented
-}
+func listen(_, _ uint32) (*Listener, error) { return nil, errUnimplemented }
 
-func dialStream(_, _ uint32) (net.Conn, error) {
-	return nil, errUnimplemented
-}
+type listener struct{}
+
+func (*listener) Accept() (net.Conn, error)     { return nil, errUnimplemented }
+func (*listener) Addr() net.Addr                { return nil }
+func (*listener) Close() error                  { return errUnimplemented }
+func (*listener) SetDeadline(_ time.Time) error { return errUnimplemented }
+
+func dial(_, _ uint32) (*Conn, error) { return nil, errUnimplemented }
+
+type connFD struct{}
+
+func (*connFD) LocalAddr() net.Addr                           { return nil }
+func (*connFD) RemoteAddr() net.Addr                          { return nil }
+func (*connFD) SetDeadline(_ time.Time, _ deadlineType) error { return errUnimplemented }
+func (*connFD) Read(_ []byte) (int, error)                    { return 0, errUnimplemented }
+func (*connFD) Write(_ []byte) (int, error)                   { return 0, errUnimplemented }
+func (*connFD) Close() error                                  { return errUnimplemented }
+func (*connFD) Shutdown(_ int) error                          { return errUnimplemented }
+func (*connFD) SyscallConn() (syscall.RawConn, error)         { return nil, errUnimplemented }
+
+func contextID() (uint32, error) { return 0, errUnimplemented }
+
+func isErrno(_ error, _ int) bool { return false }


### PR DESCRIPTION
This version of vsock fully supports Go 1.12 runtime network poller
integration, and is compliant with net.Listener and net.Conn as
checked by golang.org/x/net/nettest.

Fixes #485.

Signed-off-by: Matt Layher <mdlayher@gmail.com>