### PR TITLE
channel: Check for channel type in kernel cmdline options

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -155,6 +155,22 @@ var collatedTrace = false
 // if true, coredump when an internal error occurs or a fatal signal is received
 var crashOnError = false
 
+// commType is used to denote the communication channel type used.
+type commType int
+
+const (
+	// virtio-serial channel
+	serialCh commType = iota
+
+	// vsock channel
+	vsockCh
+
+	// channel type not passed explicitly
+	unknownCh
+)
+
+var commCh = unknownCh
+
 // This is the list of file descriptors we can properly close after the process
 // has been started. When the new process is exec(), those file descriptors are
 // duplicated and it is our responsibility to close them since we have opened

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"io/ioutil"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -20,6 +21,7 @@ const (
 	logLevelFlag       = optionPrefix + "log"
 	devModeFlag        = optionPrefix + "devmode"
 	traceModeFlag      = optionPrefix + "trace"
+	useVsockFlag       = optionPrefix + "use_vsock"
 	kernelCmdlineFile  = "/proc/cmdline"
 	traceValueIsolated = "isolated"
 	traceValueCollated = "collated"
@@ -101,6 +103,18 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 			enableTracing(false)
 		case traceValueCollated:
 			enableTracing(true)
+		}
+	case useVsockFlag:
+		flag, err := strconv.ParseBool(split[valuePosition])
+		if err != nil {
+			return err
+		}
+		if flag {
+			agentLog.Debug("Param passed to use vsock channel")
+			commCh = vsockCh
+		} else {
+			agentLog.Debug("Param passed to NOT use vsock channel")
+			commCh = serialCh
 		}
 	default:
 		if strings.HasPrefix(split[optionPosition], optionPrefix) {

--- a/config_test.go
+++ b/config_test.go
@@ -285,3 +285,46 @@ func TestEnableTracing(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCmdlineOptionWrongOptionVsock(t *testing.T) {
+	t.Skip()
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	wrongOption := "use_vsockkk=true"
+
+	err := a.parseCmdlineOption(wrongOption)
+	assert.Errorf(err, "Parsing should fail because wrong option %q", wrongOption)
+}
+
+func TestParseCmdlineOptionsVsock(t *testing.T) {
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	type testData struct {
+		val            string
+		shouldErr      bool
+		expectedCommCh commType
+	}
+
+	data := []testData{
+		{"true", false, vsockCh},
+		{"false", false, serialCh},
+		{"blah", true, unknownCh},
+	}
+
+	for _, d := range data {
+		commCh = unknownCh
+		option := useVsockFlag + "=" + d.val
+
+		err := a.parseCmdlineOption(option)
+		if d.shouldErr {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+		}
+		assert.Equal(commCh, d.expectedCommCh)
+	}
+}


### PR DESCRIPTION
With a recent kernel change, the agent can no longer rely on
/dev/vsock and AF_VSOCK in socket(), to detect if vhost-vsock
channel has been passed by the runtime.
These are not created when the vhost-vsock driver is initialised.

The runtime should now pass this information explicilty.
Based on the channel type passed, the agent now checks for that
partcular channel type.
In case it is not passed, check for both serial and vsock channel.
This also introduces a change in the way vsock channel is detected
by checking for devices under the vhost-vsock driver path.

Fixes #506

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit 2af3599360a9bdac04c7c11ce9a340633b85cd39)