### PR TITLE
agent: Fix "agent grpc server quits" show wrong error

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1052,7 +1052,7 @@ func (s *sandbox) startGRPC() {
 			// l is closed when Serve() returns
 			servErr = grpcServer.Serve(l)
 			if servErr != nil {
-				agentLog.WithError(err).Warn("agent grpc server quits")
+				agentLog.WithError(servErr).Warn("agent grpc server quits")
 			}
 
 			err = s.channel.teardown()


### PR DESCRIPTION
It should show servErr but not err.

Fixes: #511

Signed-off-by: Hui Zhu <teawater@hyper.sh>