### PR TITLE
ci: travis: checkout test repo to correct branch

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -16,6 +16,10 @@ clone_tests_repo()
 	fi
 
 	go get -d -u "$tests_repo" || true
+
+	if [ -n "${TRAVIS_BRANCH:-}" ]; then
+		( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
+	fi
 }
 
 run_static_checks()


### PR DESCRIPTION
If we are testing an stable branch, we need to checkout
to the correct branch on the tests repository.

Fixes: #516.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>