### PR TITLE
agent: Add support for local storage

### DIFF
--- a/device.go
+++ b/device.go
@@ -31,6 +31,7 @@ const (
 	driverSCSIType      = "scsi"
 	driverNvdimmType    = "nvdimm"
 	driverEphemeralType = "ephemeral"
+	driverLocalType     = "local"
 )
 
 const (


### PR DESCRIPTION
Local storage is just a directory created inside the VM.
This will use whatever the storage driver is for the container
rootfs. This will normally be 9p, but in some cases could be
device mapper. In this case the directory will benefit from the improved
performance of device mapper.

Signed-off-by: Alex Price <aprice@atlassian.com>