### PR TITLE
ci: Update travis go version from 1.10 to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ language: go
 go_import_path: github.com/kata-containers/agent
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 env:
   - target_branch=$TRAVIS_BRANCH


### PR DESCRIPTION
Update go version because golangci-lint v1.16.0 cannot work OK with go 1.10.

Fixes: #527

Signed-off-by: Hui Zhu <teawater@hyper.sh>