### PR TITLE
agent: send SIGKILL instead of SIGTERM to container init process

### DIFF
--- a/grpc_test.go
+++ b/grpc_test.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -835,4 +836,24 @@ func TestCopyFile(t *testing.T) {
 	assert.NoError(err)
 	// check file's content
 	assert.Equal(content, append(part1, part2...))
+}
+
+func TestIsSignalHandled(t *testing.T) {
+	assert := assert.New(t)
+	pid := 1
+
+	// process will not handle SIGKILL signal
+	signum := syscall.SIGKILL
+	handled := isSignalHandled(pid, signum)
+	assert.False(handled)
+
+	// init process will not handle SIGTERM signal
+	signum = syscall.SIGTERM
+	handled = isSignalHandled(pid, signum)
+	assert.False(handled)
+
+	// init process will handle the SIGQUIT signal
+	signum = syscall.SIGQUIT
+	handled = isSignalHandled(pid, signum)
+	assert.True(handled)
 }


### PR DESCRIPTION
## Backported:
c624f63 Merge pull request #526 from lifupan/stopfix
7fbd860 agent: send SIGKILL instead of SIGTERM to container init process




## Not backported:
7720b93 Merge pull request #480 from jodh-intel/fix-user-initiated-shutdown
85e0942 docs: Explain shutdown behaviour with tracing
99d6118 docs: Define "VM" in tracing doc
353ec2d service: Fix user initiated shutdown with static tracing

34209ea Merge pull request #521 from awprice/local-storage-type
8847998 agent: Add support for local storage

bf5f5ab Merge pull request #529 from sboeuf/fix_exec_vndr
cb32d28 test: Fix mockContainer
3e12793 agent: Fix container creation
6e558f7 vendor: Update libcontainer vendoring

aa37186 Merge pull request #523 from teawater/static_build
8b34aaf make: Add build option STATIC=1 to statically link

801d792 Merge pull request #528 from teawater/lint
01b1cb2 travis: Use xenial
d815c97 lint: Update code to handle lint issues
828b417 ci: Update travis go version from 1.10 to 1.11