### PR TITLE
updateInterface: enable hot-add nic on arm64

### DIFF
--- a/device.go
+++ b/device.go
@@ -35,8 +35,7 @@ const (
 )
 
 const (
-	rootBusPath = "/devices/pci0000:00"
-	pciBusMode  = 0220
+	pciBusMode = 0220
 )
 
 var (

--- a/device_amd64.go
+++ b/device_amd64.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+const (
+	rootBusPath = "/devices/pci0000:00"
+)

--- a/device_arm64.go
+++ b/device_arm64.go
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+const rootBusPath = "/devices/platform/4010000000.pcie/pci0000:00"

--- a/device_ppc64le.go
+++ b/device_ppc64le.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+const (
+	rootBusPath = "/devices/pci0000:00"
+)

--- a/device_s390x.go
+++ b/device_s390x.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+const (
+	rootBusPath = "/devices/pci0000:00"
+)


### PR DESCRIPTION
    For now, update interface in agent will fail when hot-add
    nic to a running containers on arm64 as rescan pci bus will
    occur between uf and bf of shpc hotplug interrupt handling.

    Another problem is that the rootBusPath will be
    "/devices/platform/4010000000.pcie/pci0000:00" on arm64.

    To enable hot-add nic on arm64, rootBusPath should be changed here
    and shpc hotplug should be disabled in guest kernel.

    This patch just change rootBusPath.

Fixes: #544
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@bergwolf @jodh-intel @teawater @Pennyzct 