### PR TITLE
agent: support debug console

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [Debug mode](#debug-mode)
 * [Developer mode](#developer-mode)
 * [Enable trace support](#enable-trace-support)
+* [Enable debug console](#enable-debug-console)
 
 This project implements an agent called `kata-agent` that runs inside a virtual machine (VM).
 
@@ -27,3 +28,10 @@ enables [debug mode](#debug-mode).
 ## Enable trace support
 
 See [the tracing guide](TRACING.md).
+
+## Enable debug console
+
+Add `agent.debug_console` to the guest kernel command line to
+allow the agent process to start a debug console. Debug console is only available if `bash`
+or `sh` is installed in the rootfs or initrd image. Developers can [connect to the virtual
+machine using the debug console](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#connect-to-the-virtual-machine-using-the-debug-console)

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ const (
 	devModeFlag       = optionPrefix + "devmode"
 	traceModeFlag     = optionPrefix + "trace"
 	useVsockFlag      = optionPrefix + "use_vsock"
+	debugConsoleFlag  = optionPrefix + "debug_console"
 	kernelCmdlineFile = "/proc/cmdline"
 	traceModeStatic   = "static"
 	traceModeDynamic  = "dynamic"
@@ -76,6 +77,11 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 		crashOnError = true
 		debug = true
 
+		return nil
+	}
+
+	if option == debugConsoleFlag {
+		debugConsole = true
 		return nil
 	}
 


### PR DESCRIPTION
Start a debug console if the `agent.debug_console` option is part of the kernel
command line and a shell (bash or sh) is installed in the rootfs.
The debug console is useful when the developer wants to debug the agent process
or any other processes (even containers). The current way to do this is by
modifying a systemd target + creating a new system unit, the problem with this
approach is that it's not user-friendly and we depend on systemd, since it must
be installed in the rootfs.

fixes #546

Signed-off-by: Julio Montes <julio.montes@intel.com>