### PR TITLE
vendor: update vsock package version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -126,11 +126,11 @@
   revision = "cc6d2ea263b2471faabce371255777a365bf8306"
 
 [[projects]]
-  digest = "1:79062b1e6d284b7a41cf04ba20f5dbc371a4fdd5edaca748ddb827ab07846dbf"
+  digest = "1:b09f78822be5d574e052d4e377b133bac445cdbcbfaf884e0704f870e509ef21"
   name = "github.com/mdlayher/vsock"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "a92c53d5dcabbf6aaaba8fe07983d4f10f812fa7"
+  revision = "7b7533a7ca4eba7dd23dab2de70e25ca6eecf7e2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/mdlayher/vsock"
-  revision = "a92c53d5dcabbf6aaaba8fe07983d4f10f812fa7"
+  revision = "7b7533a7ca4eba7dd23dab2de70e25ca6eecf7e2"
 
 [[constraint]]
   name = "github.com/opencontainers/runc"

--- a/vendor/github.com/mdlayher/vsock/doc.go
+++ b/vendor/github.com/mdlayher/vsock/doc.go
@@ -42,6 +42,8 @@
 //
 // Go 1.10 and below are not supported. The runtime network poller integration
 // required by this package is not available in Go versions prior to Go 1.11.
+// Unsupported versions of Go will produce a compilation error when trying to
+// build this package.
 //
 // Stability
 //

--- a/vendor/github.com/mdlayher/vsock/goversion_unsupported.go
+++ b/vendor/github.com/mdlayher/vsock/goversion_unsupported.go
@@ -1,0 +1,9 @@
+//+build !go1.11
+
+package vsock
+
+func init() {
+	// Intentionally break compilation on unsupported versions of Go, but
+	// produce a somewhat informative build failure output.
+	UpgradeGoCompilerToUseThisPackage
+}


### PR DESCRIPTION
The vsock package needs go >= 1.11. The latest version of the package adds a
compile time check on the go version.

Fixes: #542

Signed-off-by: Marco Vedovati <mvedovati@suse.com>