### PR TITLE
docs: Add missing document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * [Developer mode](#developer-mode)
 * [Enable trace support](#enable-trace-support)
 * [Enable debug console](#enable-debug-console)
+* [`cpuset` cgroup details](#cpuset-cgroup-details)
 
 This project implements an agent called `kata-agent` that runs inside a virtual machine (VM).
 
@@ -35,3 +36,7 @@ Add `agent.debug_console` to the guest kernel command line to
 allow the agent process to start a debug console. Debug console is only available if `bash`
 or `sh` is installed in the rootfs or initrd image. Developers can [connect to the virtual
 machine using the debug console](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#connect-to-the-virtual-machine-using-the-debug-console)
+
+## `cpuset` cgroup details
+
+See the [cupset cgroup documentation](documentation/features/cpuset.md).


### PR DESCRIPTION
Add link in the README to the existing cpuset doc which previously was not very visible.

Fixes #557.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>