### PR TITLE
tmp: Add tmp.mount to kata-containers.target

### DIFF
--- a/kata-containers.target
+++ b/kata-containers.target
@@ -7,6 +7,7 @@
 [Unit]
 Description=Kata Containers Agent Target
 Requires=basic.target
+Requires=tmp.mount
 Wants=chronyd.service
 Requires=kata-agent.service
 Conflicts=rescue.service rescue.target


### PR DESCRIPTION
Invoke tmp.mount by adding it to kata-containers.target.
This is not invoked by systemd with current rootfs setup we have
as one of the dependencies for tmp.mount is systemd-remount-fs.service
which depends on /etc/fstab file being present(it is currenty missing)
Instead of adding that file, start the tmp.mount unit by including
it in kata-containers.target

With this and change in os-builder to not delete the tmp.mount unit,
(https://github.com/kata-containers/osbuilder/pull/301) /tmp should now
be writeable for systemd based images.
For initrd this is handled by the agent itself.

Fixes #https://github.com/kata-containers/osbuilder/issues/300

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>