### PR TITLE
mount: Virtio-blk container rootfs mount for ACRN hypervisor

### DIFF
--- a/mount_test.go
+++ b/mount_test.go
@@ -125,6 +125,30 @@ func TestVirtio9pStorageHandlerSuccessful(t *testing.T) {
 	assert.Nil(t, err, "storage9pDriverHandler() failed: %v", err)
 }
 
+func TestVirtioBlkStoragePathFailure(t *testing.T) {
+	s := &sandbox{}
+
+	storage := pb.Storage{
+		Source: "/home/developer/test",
+	}
+
+	_, err := virtioBlkStorageHandler(storage, s)
+	agentLog.WithError(err).Error("virtioBlkStorageHandler error")
+	assert.NotNil(t, err, "virtioBlkStorageHandler() should have failed")
+}
+
+func TestVirtioBlkStorageDeviceFailure(t *testing.T) {
+	s := &sandbox{}
+
+	storage := pb.Storage{
+		Source: "/dev/foo",
+	}
+
+	_, err := virtioBlkStorageHandler(storage, s)
+	agentLog.WithError(err).Error("virtioBlkStorageHandler error")
+	assert.NotNil(t, err, "virtioBlkStorageHandler() should have failed")
+}
+
 func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
 	skipUnlessRoot(t)
 


### PR DESCRIPTION
For block devices added by acrn, virtpath is directly udpated
in storage.source and so no scanning of PCIAddr is required.
This is because, the virtio-blk device is not hot-plugged but
added during VM launch and updated later with container rootfs
using block rescan feature.

Fixes: #573

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>