### PR TITLE
agent: sandbox_pause should not take arguments

### DIFF
--- a/pause.go
+++ b/pause.go
@@ -9,18 +9,36 @@ package main
 /*
 #cgo CFLAGS: -Wall
 #define _GNU_SOURCE
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 
 #define PAUSE_BIN "pause-bin"
 
-void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
-	if (argc != 2 || strcmp(argv[1], PAUSE_BIN)) {
-		return;
+void __attribute__((constructor)) sandbox_pause(void) {
+	FILE *f;
+	int len, do_pause = 0;
+	size_t n = 0;
+	char *p = NULL;
+
+	f = fopen("/proc/self/cmdline", "r");
+	if (f == NULL) {
+		perror("failed to open proc");
+		exit(-errno);
 	}
+	while ((len = getdelim(&p, &n, '\0', f)) != -1) {
+		if (len == sizeof(PAUSE_BIN) && !strncmp(p, PAUSE_BIN, sizeof(PAUSE_BIN)-1)) {
+			do_pause = 1;
+			break;
+		}
+	}
+	fclose(f);
+	free(p);
+
+	if (do_pause == 0)
+		return;
 
 	for (;;) pause();
 


### PR DESCRIPTION
gcc __attribute__ constructors cannot take arguments and cannot
access main function arguments on musl. Such functionality is glibc
specific and only works on x86 and x86_64. As a result, the pause
binary always quits on musl causing sandbox share pidns to malfunction.
