### PR TITLE
network: setupDNS for sandbox

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -1441,7 +1441,7 @@ func (a *agentGRPC) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequ
 
 	a.sandbox.mounts = mountList
 
-	if err := setupDNS(a.sandbox.network.dns); err != nil {
+	if err := setupDNS(); err != nil {
 		return emptyResp, err
 	}
 


### PR DESCRIPTION
In order to set hostname, dns etc of the VM, we
need to copy these files from host to VM rootfs
and not container rootfs.

Fixes:  #589

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com