### PR TITLE
vendor: Update the vendoring for github.com/opencontainers/runtime-spec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -166,11 +166,11 @@
   revision = "f56b4cbeadc407e715d9b2ba49e62185bd81cef4"
 
 [[projects]]
-  digest = "1:0d447d4961f4f9270457fbc20d0261bba8d3056f395efd2e2480e2dfa4487a60"
+  digest = "1:87ce99b0c7c54a10c8d7ec55885e37efc81a6bff1fd8435d39badeb9934c9043"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
   pruneopts = "NUT"
-  revision = "5806c35637336642129d03657419829569abc5aa"
+  revision = "a950415649c735f9fd9ec3b8869efef24b67cef4"
 
 [[projects]]
   digest = "1:5c65c485fa22fdfd6937db07aaf879904a4745770ee416d8d1f2a1434dc2d8ce"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"
-  revision = "5806c35637336642129d03657419829569abc5aa"
+  revision = "a950415649c735f9fd9ec3b8869efef24b67cef4"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -38,7 +38,9 @@ type Process struct {
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
-	Args []string `json:"args"`
+	Args []string `json:"args,omitempty"`
+	// CommandLine specifies the full command line for the application to execute on Windows.
+	CommandLine string `json:"commandLine,omitempty" platform:"windows"`
 	// Env populates the process environment for the process.
 	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be
@@ -181,17 +183,17 @@ const (
 	// PIDNamespace for isolating process IDs
 	PIDNamespace LinuxNamespaceType = "pid"
 	// NetworkNamespace for isolating network devices, stacks, ports, etc
-	NetworkNamespace = "network"
+	NetworkNamespace LinuxNamespaceType = "network"
 	// MountNamespace for isolating mount points
-	MountNamespace = "mount"
+	MountNamespace LinuxNamespaceType = "mount"
 	// IPCNamespace for isolating System V IPC, POSIX message queues
-	IPCNamespace = "ipc"
+	IPCNamespace LinuxNamespaceType = "ipc"
 	// UTSNamespace for isolating hostname and NIS domain name
-	UTSNamespace = "uts"
+	UTSNamespace LinuxNamespaceType = "uts"
 	// UserNamespace for isolating user and group IDs
-	UserNamespace = "user"
+	UserNamespace LinuxNamespaceType = "user"
 	// CgroupNamespace for isolating cgroup hierarchies
-	CgroupNamespace = "cgroup"
+	CgroupNamespace LinuxNamespaceType = "cgroup"
 )
 
 // LinuxIDMapping specifies UID/GID mappings
@@ -217,6 +219,7 @@ type POSIXRlimit struct {
 // LinuxHugepageLimit structure corresponds to limiting kernel hugepages
 type LinuxHugepageLimit struct {
 	// Pagesize is the hugepage size
+	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.)
 	Pagesize string `json:"pageSize"`
 	// Limit is the limit of "hugepagesize" hugetlb usage
 	Limit uint64 `json:"limit"`
@@ -528,7 +531,7 @@ type VMHypervisor struct {
 	// Path is the host path to the hypervisor used to manage the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the hypervisor.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 }
 
 // VMKernel contains information about the kernel to use for a virtual machine.
@@ -536,7 +539,7 @@ type VMKernel struct {
 	// Path is the host path to the kernel used to boot the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the kernel.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 	// InitRD is the host path to an initial ramdisk to be used by the kernel.
 	InitRD string `json:"initrd,omitempty"`
 }
@@ -632,7 +635,9 @@ type LinuxIntelRdt struct {
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
 
-	// The schema of memory bandwidth percentage per L3 cache id
+	// The schema of memory bandwidth per L3 cache id
 	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
 }


### PR DESCRIPTION
The latest commit introduces quite a few changes in the VM spec.
These are required by the runtime. Without this we cannot update the
vendoring in the runtime for the runtime-spec.

Fixes #597

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>