### PR TITLE
s390x: add virtio-blk-ccw support

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -779,3 +779,45 @@ func TestGetSCSIDevPath(t *testing.T) {
 	cancel()
 
 }
+
+func TestFindBlkCCWDevPath(t *testing.T) {
+	bus := "0.0.0005"
+	assert := assert.New(t)
+	expectDev := "vdb"
+	dir := fmt.Sprintf("/tmp/sys/bus/ccw/devices/%s/virtio5/block/%s", bus, expectDev)
+	busPath := fmt.Sprintf("/tmp/sys/bus/ccw/devices/%s", bus)
+	err := os.MkdirAll(dir, mountPerm)
+	assert.Nil(err)
+
+	dev, err := findBlkCCWDevPath(busPath)
+	assert.Nil(err)
+
+	if dev != expectDev {
+		t.Errorf("Expected value %s got %s", expectDev, dev)
+	}
+
+	bus = "../dev"
+	busPath = fmt.Sprintf("/tmp/sys/bus/ccw/devices/%s", bus)
+	err = os.MkdirAll(dir, mountPerm)
+	assert.Nil(err)
+	_, err = findBlkCCWDevPath(busPath)
+	assert.NotNil(err, fmt.Sprintf("findBlkCCWDevPath() should have been failed with bus %s", bus))
+
+}
+
+func TestCheckCCWBusFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	wrongBuses := []string{"", "fe.0.0000", "0.5.0000", "some_wrong_path", "0.1.fffff", "0.0.0"}
+	rightBuses := []string{"0.3.abcd", "0.0.0000", "0.1.0000"}
+
+	for _, bus := range wrongBuses {
+		err := checkCCWBusFormat(bus)
+		assert.NotNil(err, fmt.Sprintf("checkCCWBusFormat() should have been failed with bus %s", bus))
+	}
+
+	for _, bus := range rightBuses {
+		err := checkCCWBusFormat(bus)
+		assert.Nil(err)
+	}
+}

--- a/mount.go
+++ b/mount.go
@@ -213,6 +213,7 @@ var storageHandlerList = map[string]storageHandler{
 	driver9pType:        virtio9pStorageHandler,
 	driverVirtioFSType:  virtioFSStorageHandler,
 	driverBlkType:       virtioBlkStorageHandler,
+	driverBlkCCWType:    virtioBlkCCWStorageHandler,
 	driverMmioBlkType:   virtioMmioBlkStorageHandler,
 	driverSCSIType:      virtioSCSIStorageHandler,
 	driverEphemeralType: ephemeralStorageHandler,
@@ -265,6 +266,20 @@ func virtio9pStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (
 // virtioMmioBlkStorageHandler handles the storage for mmio blk driver.
 func virtioMmioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	//The source path is VmPath
+	return commonStorageHandler(storage)
+}
+
+// virtioBlkCCWStorageHandler handles the storage for blk ccw driver.
+func virtioBlkCCWStorageHandler(ctx context.Context, storage pb.Storage, s *sandbox) (string, error) {
+	devPath, err := getBlkCCWDevPath(ctx, storage.Source)
+	if err != nil {
+		return "", err
+	}
+	if devPath == "" {
+		return "", grpcStatus.Errorf(codes.InvalidArgument,
+			"Storage source is empty")
+	}
+	storage.Source = devPath
 	return commonStorageHandler(storage)
 }
 


### PR DESCRIPTION
Add support for CCW virtio blk. The virtio blk requires a special
handling to the PCI devices.

The divices information during the hotplug are updated in '/sys/devices/css0/',
and the disk name can be found under '/sys/bus/ccw/devices'

More detailed info at:https://public.dhe.ibm.com/software/dw/linux390/docu/lhs1vg00.pdf

Fixes: #599

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>