### PR TITLE
vendor: Move to a previous version for runtime-spec vendor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -175,11 +175,11 @@
   revision = "f4982d86f7fde0b6f953cc62ccc4022c519a10a9"
 
 [[projects]]
-  digest = "1:87ce99b0c7c54a10c8d7ec55885e37efc81a6bff1fd8435d39badeb9934c9043"
+  digest = "1:7a58202c5cdf3d2c1eb0621fe369315561cea7f036ad10f0f0479ac36bcc95eb"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
   pruneopts = "NUT"
-  revision = "a950415649c735f9fd9ec3b8869efef24b67cef4"
+  revision = "a1b50f621a48ad13f8f696a162f684a241307db0"
 
 [[projects]]
   digest = "1:3e824b6fb758a8b021d30b613d84e7404d06d33c8f43f92baed633427836736c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"
-  revision = "a950415649c735f9fd9ec3b8869efef24b67cef4"
+  revision = "a1b50f621a48ad13f8f696a162f684a241307db0"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -183,17 +183,17 @@ const (
 	// PIDNamespace for isolating process IDs
 	PIDNamespace LinuxNamespaceType = "pid"
 	// NetworkNamespace for isolating network devices, stacks, ports, etc
-	NetworkNamespace LinuxNamespaceType = "network"
+	NetworkNamespace = "network"
 	// MountNamespace for isolating mount points
-	MountNamespace LinuxNamespaceType = "mount"
+	MountNamespace = "mount"
 	// IPCNamespace for isolating System V IPC, POSIX message queues
-	IPCNamespace LinuxNamespaceType = "ipc"
+	IPCNamespace = "ipc"
 	// UTSNamespace for isolating hostname and NIS domain name
-	UTSNamespace LinuxNamespaceType = "uts"
+	UTSNamespace = "uts"
 	// UserNamespace for isolating user and group IDs
-	UserNamespace LinuxNamespaceType = "user"
+	UserNamespace = "user"
 	// CgroupNamespace for isolating cgroup hierarchies
-	CgroupNamespace LinuxNamespaceType = "cgroup"
+	CgroupNamespace = "cgroup"
 )
 
 // LinuxIDMapping specifies UID/GID mappings
@@ -219,7 +219,6 @@ type POSIXRlimit struct {
 // LinuxHugepageLimit structure corresponds to limiting kernel hugepages
 type LinuxHugepageLimit struct {
 	// Pagesize is the hugepage size
-	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.)
 	Pagesize string `json:"pageSize"`
 	// Limit is the limit of "hugepagesize" hugetlb usage
 	Limit uint64 `json:"limit"`


### PR DESCRIPTION
This is introduced as a transitive dependency for the runtime
and causes vendored pacakges to break as the change in the runtime-spec
introduces a backward incompatible change for dependent packages.

Fixes #597

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>