### PR TITLE
agent: delete element of sandbox.deviceWatchers with right key

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -736,7 +736,7 @@ func (s *sandbox) listenToUdevEvents() {
 				if ch != nil && strings.HasPrefix(uEv.DevPath, filepath.Join(rootBusPath, devPCIAddress)) {
 					ch <- uEv.DevName
 					close(ch)
-					delete(s.deviceWatchers, uEv.DevName)
+					delete(s.deviceWatchers, devPCIAddress)
 				}
 			}
 


### PR DESCRIPTION
Fixes #609

Signed-off-by: leizhongkai <leizhongkai@huawei.com>