### PR TITLE
agent: make NoPivotRoot config depend on `/` fs type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(TARGET): $(GENERATED_FILES) $(SOURCES) $(VERSION_FILE)
 	go build $(BUILDFLAGS) -tags "$(BUILDTAGS)" -o $@ \
 		-ldflags "-X main.version=$(VERSION_COMMIT) -X main.seccompSupport=$(SECCOMP) $(LDFLAGS)"
 
-install:
+install: $(TARGET)
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 ifeq ($(INIT),no)
 	@echo "Installing systemd unit files..."

--- a/agent.go
+++ b/agent.go
@@ -1327,13 +1327,18 @@ func realMain() error {
 	r := &agentReaper{}
 	r.init()
 
+	fsType, err := getMountFSType("/")
+	if err != nil {
+		return err
+	}
+
 	// Initialize unique sandbox structure.
 	s := &sandbox{
 		containers: make(map[string]*container),
 		running:    false,
-		// pivot_root won't work for init, see
-		// Documention/filesystem/ramfs-rootfs-initramfs.txt
-		noPivotRoot:    os.Getpid() == 1,
+		// pivot_root won't work for initramfs, see
+		// Documentation/filesystem/ramfs-rootfs-initramfs.txt
+		noPivotRoot:    (fsType == typeRootfs),
 		subreaper:      r,
 		pciDeviceMap:   make(map[string]string),
 		deviceWatchers: make(map[string](chan string)),

--- a/mount_test.go
+++ b/mount_test.go
@@ -605,3 +605,46 @@ func TestMountEnsureDestinationExists(t *testing.T) {
 		}
 	}
 }
+
+func TestGetMountFSType(t *testing.T) {
+	assert := assert.New(t)
+
+	// Type used to hold function parameters and expected results.
+	type testData struct {
+		param1         string
+		expectedResult string
+		expectError    bool
+	}
+
+	// List of tests to run including the expected results
+	data := []testData{
+		// failure scenarios
+		{"/thisPathShouldNotBeAMountPoint", "", true},
+
+		// success scenarios
+		{"/proc", "proc", false},
+		{"/sys", "sysfs", false},
+		{"/run", "tmpfs", false},
+	}
+
+	// Run the tests
+	for i, d := range data {
+		// Create a test-specific string that is added to each assert
+		// call. It will be displayed if any assert test fails.
+		msg := fmt.Sprintf("test[%d]: %+v", i, d)
+
+		// Call the function under test
+		result, err := getMountFSType(d.param1)
+
+		if d.expectError {
+			assert.Error(err, msg)
+
+			// If an error is expected, there is no point
+			// performing additional checks.
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.Equal(d.expectedResult, result, msg)
+	}
+}


### PR DESCRIPTION
Make NoPivotRoot depend on the actual FS type of `/` being rootfs,
instead of agent being the init process.
In this way, an initrd built without AGENT_INIT can still be used to run
containers.
    
Fixes: #611