### PR TITLE
vendor: dep check fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -410,6 +410,7 @@
     "github.com/opencontainers/runc/libcontainer/utils",
     "github.com/opencontainers/runtime-spec/specs-go",
     "github.com/opentracing/opentracing-go",
+    "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/uber/jaeger-client-go/config",


### PR DESCRIPTION
`dep check` is being run by our CI to make sure that the dependency
files and vendor repositories are in sync. This PR brings them into sync
to pass checks.

Fixes: #617
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>