### PR TITLE
revert: agent: sandbox_pause should get arguments from proc

### DIFF
--- a/pause.go
+++ b/pause.go
@@ -9,36 +9,18 @@ package main
 /*
 #cgo CFLAGS: -Wall
 #define _GNU_SOURCE
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <errno.h>
 
 #define PAUSE_BIN "pause-bin"
 
-void __attribute__((constructor)) sandbox_pause(void) {
-	FILE *f;
-	int len, do_pause = 0;
-	size_t n = 0;
-	char *p = NULL;
-
-	f = fopen("/proc/self/cmdline", "r");
-	if (f == NULL) {
-		perror("failed to open proc");
-		exit(-errno);
-	}
-	while ((len = getdelim(&p, &n, '\0', f)) != -1) {
-		if (len == sizeof(PAUSE_BIN) && !strncmp(p, PAUSE_BIN, sizeof(PAUSE_BIN)-1)) {
-			do_pause = 1;
-			break;
-		}
-	}
-	fclose(f);
-	free(p);
-
-	if (do_pause == 0)
+void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
+	if (argc != 2 || strcmp(argv[1], PAUSE_BIN)) {
 		return;
+	}
 
 	for (;;) pause();
 


### PR DESCRIPTION
When agent runs as init, it is not able to read `/proc/self/cmdline` because
of `/proc` has not been mounted when the C constructor is called.

This reverts commit cfbd8c921dea1c30532119127127e40428d5853f.

fixes #620

Signed-off-by: Julio Montes <julio.montes@intel.com>