### PR TITLE
Remove certain log messages

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -48,11 +48,6 @@ func getAvailableCpusetList(cpusetReq string) (string, error) {
 
 	for k := range cpusetListReq {
 		if !cpusetGuestList[k] {
-			agentLog.WithFields(logrus.Fields{
-				"cpuset":     cpusetReq,
-				"cpu":        k,
-				"guest-cpus": cpusetGuest,
-			}).Warnf("cpu is not in guest cpu list, using guest cpus")
 			return cpusetGuest, nil
 		}
 	}


### PR DESCRIPTION
logs: Remove certain logs that are repeatedly printed.
    
 When using static cpu policy, grpc request to update CPUs is
 being called over and over again. These logs create a lot of
 chatter in the journal as well make the debug console quite
 unusable. So get rid of these.
