### PR TITLE
device: fix the issue of failed waiting on device appeared in /dev

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -733,12 +733,36 @@ func (s *sandbox) listenToUdevEvents() {
 
 			// Notify watchers that are interested in the udev event.
 			// Close the channel after watcher has been notified.
-			for devPCIAddress, ch := range s.deviceWatchers {
-				if ch != nil && strings.HasPrefix(uEv.DevPath, filepath.Join(rootBusPath, devPCIAddress)) {
-					ch <- uEv.DevName
-					close(ch)
-					delete(s.deviceWatchers, devPCIAddress)
+			for devAddress, ch := range s.deviceWatchers {
+				if ch == nil {
+					continue
 				}
+
+				fieldLogger.Infof("Got a wait channel for device %s", devAddress)
+
+				// blk driver case
+				if strings.HasPrefix(uEv.DevPath, filepath.Join(rootBusPath, devAddress)) {
+					goto OUT
+				}
+
+				if strings.Contains(uEv.DevPath, devAddress) {
+					// scsi driver case
+					if strings.HasSuffix(devAddress, scsiBlockSuffix) {
+						goto OUT
+					}
+					// blk-ccw driver case
+					if strings.HasSuffix(devAddress, blkCCWSuffix) {
+						goto OUT
+					}
+				}
+
+				continue
+
+			OUT:
+				ch <- uEv.DevName
+				close(ch)
+				delete(s.deviceWatchers, devAddress)
+
 			}
 
 			s.Unlock()

--- a/mount.go
+++ b/mount.go
@@ -30,7 +30,6 @@ const (
 	typeVirtioFS   = "virtio_fs"
 	typeRootfs     = "rootfs"
 	typeTmpFs      = "tmpfs"
-	devPrefix      = "/dev/"
 	procMountStats = "/proc/self/mountstats"
 	mountPerm      = os.FileMode(0755)
 )
@@ -271,7 +270,7 @@ func virtioMmioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandb
 
 // virtioBlkCCWStorageHandler handles the storage for blk ccw driver.
 func virtioBlkCCWStorageHandler(ctx context.Context, storage pb.Storage, s *sandbox) (string, error) {
-	devPath, err := getBlkCCWDevPath(ctx, storage.Source)
+	devPath, err := getBlkCCWDevPath(s, storage.Source)
 	if err != nil {
 		return "", err
 	}
@@ -319,7 +318,7 @@ func virtioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) 
 // virtioSCSIStorageHandler handles the storage for scsi driver.
 func virtioSCSIStorageHandler(ctx context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	// Retrieve the device path from SCSI address.
-	devPath, err := getSCSIDevPath(ctx, storage.Source)
+	devPath, err := getSCSIDevPath(s, storage.Source)
 	if err != nil {
 		return "", err
 	}

--- a/mount_test.go
+++ b/mount_test.go
@@ -242,7 +242,7 @@ func TestVirtioSCSIStorageHandlerFailure(t *testing.T) {
 	const expectedDevPath = "/dev/some/where"
 
 	savedSCSIDevPathFunc := getSCSIDevPath
-	getSCSIDevPath = func(_ context.Context, scsiAddr string) (string, error) {
+	getSCSIDevPath = func(s *sandbox, scsiAddr string) (string, error) {
 		return expectedDevPath, nil
 	}
 


### PR DESCRIPTION
There is an issue with the waitForDevice:
this wait will first check is the device's sys entry existed in /sys directory,
and if it existed, then it would return directly. How ever, the kernel register
a new device as an order of: 1) create the sys entry in /sys; 2) mknod in devtmpfs;
3) send uevent to userspace. The problem here is when the "wait" tested the sys entry
existed and return directly, but at that time the kernel would haven't created the device
node in devtmpfs, thus the following mount failed with couldn't resolve the device path.

Thus, the correct choice for waiting the device is depends on the uevent notice, since
once the kernel sended the device "add" uevent, it had created the device node in devtmpfs
yet.

Fixes: #628

Signed-off-by: lifupan <lifupan@gmail.com>