### PR TITLE
mount: ensure local directory storage types have the correct permissions

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -252,7 +252,13 @@ func localStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (str
 			mode = os.FileMode(m)
 		}
 
-		return "", os.MkdirAll(storage.MountPoint, mode)
+		if err := os.MkdirAll(storage.MountPoint, mode); err != nil {
+			return "", err
+		}
+
+		// We chmod the permissions for the mount point, as we can't rely on os.MkdirAll to set the
+		// desired permissions.
+		return "", os.Chmod(storage.MountPoint, mode)
 	}
 	return "", nil
 }


### PR DESCRIPTION
This commit ensures that local directory storage types have the correct
permissions set on the mount point. We can't rely on os.MkdirAll to
set the desired permissions, as the agent process umask will determine
the permissions on the created directory. To fix this we call os.Chmod
on the mount point with the desired permissions.

Additional tests have been added.

Fixes #636

Signed-off-by: Alex Price <aprice@atlassian.com>