### PR TITLE
Backports for 1.8 stable branch

### DIFF
--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+clone_tests_repo
+
+pushd "${tests_repo_dir}"
+.ci/install_go.sh -p -f
+popd

--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -11,6 +11,12 @@ source "${cidir}/lib.sh"
 
 clone_tests_repo
 
+new_goroot=/usr/local/go
+
 pushd "${tests_repo_dir}"
-.ci/install_go.sh -p -f
+# Force overwrite the current version of golang
+[ -z "${GOROOT}" ] || rm -rf "${GOROOT}"
+.ci/install_go.sh -p -f -d "$(dirname ${new_goroot})"
+[ -z "${GOROOT}" ] || sudo ln -sf "${new_goroot}" "${GOROOT}"
+go version
 popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,17 @@ os:
 language: go
 go_import_path: github.com/kata-containers/agent
 
-go:
-  - "1.11.x"
-
 env:
   - target_branch=$TRAVIS_BRANCH
 
 before_script:
+  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq automake
+  - sudo apt-get install -y moreutils
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ env:
   - target_branch=$TRAVIS_BRANCH
 
 before_script:
-  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq automake
   - sudo apt-get install -y moreutils
+  - ".ci/install_go.sh"
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -410,6 +410,7 @@
     "github.com/opencontainers/runc/libcontainer/utils",
     "github.com/opencontainers/runtime-spec/specs-go",
     "github.com/opentracing/opentracing-go",
+    "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/uber/jaeger-client-go/config",

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(TARGET): $(GENERATED_FILES) $(SOURCES) $(VERSION_FILE)
 	go build $(BUILDFLAGS) -tags "$(BUILDTAGS)" -o $@ \
 		-ldflags "-X main.version=$(VERSION_COMMIT) -X main.seccompSupport=$(SECCOMP) $(LDFLAGS)"
 
-install:
+install: $(TARGET)
 	install -D $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 ifeq ($(INIT),no)
 	@echo "Installing systemd unit files..."

--- a/agent.go
+++ b/agent.go
@@ -42,7 +42,6 @@ import (
 
 const (
 	procCgroups = "/proc/cgroups"
-	meminfo     = "/proc/meminfo"
 
 	bashPath         = "/bin/bash"
 	shPath           = "/bin/sh"
@@ -50,6 +49,8 @@ const (
 )
 
 var (
+	meminfo = "/proc/meminfo"
+
 	// cgroup fs is mounted at /sys/fs when systemd is the init process
 	sysfsDir                     = "/sys"
 	cgroupPath                   = sysfsDir + "/fs/cgroup"

--- a/agent.go
+++ b/agent.go
@@ -737,7 +737,7 @@ func (s *sandbox) listenToUdevEvents() {
 				if ch != nil && strings.HasPrefix(uEv.DevPath, filepath.Join(rootBusPath, devPCIAddress)) {
 					ch <- uEv.DevName
 					close(ch)
-					delete(s.deviceWatchers, uEv.DevName)
+					delete(s.deviceWatchers, devPCIAddress)
 				}
 			}
 

--- a/agent.go
+++ b/agent.go
@@ -411,21 +411,18 @@ func (s *sandbox) unsetAndRemoveSandboxStorage(path string) error {
 	span.SetTag("path", path)
 	defer span.Finish()
 
-	if _, ok := s.storages[path]; ok {
-		removeSbs, err := s.unSetSandboxStorage(path)
-		if err != nil {
+	removeSbs, err := s.unSetSandboxStorage(path)
+	if err != nil {
+		return err
+	}
+
+	if removeSbs {
+		if err := s.removeSandboxStorage(path); err != nil {
 			return err
 		}
-
-		if removeSbs {
-			if err := s.removeSandboxStorage(path); err != nil {
-				return err
-			}
-		}
-
-		return nil
 	}
-	return grpcStatus.Errorf(codes.NotFound, "Sandbox storage with path %s not found", path)
+
+	return nil
 }
 
 func (s *sandbox) getContainer(id string) (*container, error) {

--- a/agent.go
+++ b/agent.go
@@ -843,6 +843,9 @@ func getMemory() (string, error) {
 		}
 
 		memTotal := strings.TrimSpace(fields[1])
+		if memTotal == "" {
+			return "", fmt.Errorf("cannot determine total memory from line %q", line)
+		}
 
 		return memTotal, nil
 	}

--- a/agent.go
+++ b/agent.go
@@ -1177,9 +1177,9 @@ func mountToRootfs(m initMount) error {
 		return err
 	}
 
-	if flags, options, err := parseMountFlagsAndOptions(m.options); err != nil {
-		return grpcStatus.Errorf(codes.Internal, "Could not parseMountFlagsAndOptions(%v)", m.options)
-	} else if err := syscall.Mount(m.src, m.dest, m.fstype, uintptr(flags), options); err != nil {
+	flags, options := parseMountFlagsAndOptions(m.options)
+
+	if err := syscall.Mount(m.src, m.dest, m.fstype, uintptr(flags), options); err != nil {
 		return grpcStatus.Errorf(codes.Internal, "Could not mount %v to %v: %v", m.src, m.dest, err)
 	}
 	return nil

--- a/agent.go
+++ b/agent.go
@@ -391,11 +391,11 @@ func (s *sandbox) removeSandboxStorage(path string) error {
 
 	err := removeMounts([]string{path})
 	if err != nil {
-		return grpcStatus.Errorf(codes.Unknown, "Unable to unmount sandbox storage path %s", path)
+		return grpcStatus.Errorf(codes.Unknown, "Unable to unmount sandbox storage path %s: %v", path, err)
 	}
 	err = os.RemoveAll(path)
 	if err != nil {
-		return grpcStatus.Errorf(codes.Unknown, "Unable to delete sandbox storage path %s", path)
+		return grpcStatus.Errorf(codes.Unknown, "Unable to delete sandbox storage path %s: %v", path, err)
 	}
 	return nil
 }

--- a/agent.go
+++ b/agent.go
@@ -1327,13 +1327,18 @@ func realMain() error {
 	r := &agentReaper{}
 	r.init()
 
+	fsType, err := getMountFSType("/")
+	if err != nil {
+		return err
+	}
+
 	// Initialize unique sandbox structure.
 	s := &sandbox{
 		containers: make(map[string]*container),
 		running:    false,
-		// pivot_root won't work for init, see
-		// Documention/filesystem/ramfs-rootfs-initramfs.txt
-		noPivotRoot:    os.Getpid() == 1,
+		// pivot_root won't work for initramfs, see
+		// Documentation/filesystem/ramfs-rootfs-initramfs.txt
+		noPivotRoot:    (fsType == typeRootfs),
 		subreaper:      r,
 		pciDeviceMap:   make(map[string]string),
 		deviceWatchers: make(map[string](chan string)),

--- a/agent_test.go
+++ b/agent_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -18,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/specconv"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -27,6 +30,7 @@ const (
 	testExecID      = "testExecID"
 	testContainerID = "testContainerID"
 	testFileMode    = os.FileMode(0640)
+	testDirMode     = os.FileMode(0750)
 )
 
 func createFileWithPerms(file, contents string, perms os.FileMode) error {
@@ -48,6 +52,12 @@ func createEmptyFileWithPerms(file string, perms os.FileMode) error {
 func skipUnlessRoot(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("Test disabled as requires root user")
+	}
+}
+
+func skipIfRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Test disabled as requires non-root user")
 	}
 }
 
@@ -216,25 +226,107 @@ func TestSetSandboxStorage(t *testing.T) {
 	assert.Equal(t, 2, refCount, "Invalid refcount, got %d expected 2", refCount)
 }
 
+func bindMount(src, dest string) error {
+	return mount(src, dest, "bind", syscall.MS_BIND, "")
+}
+
 func TestRemoveSandboxStorage(t *testing.T) {
+	skipUnlessRoot(t)
+
 	s := &sandbox{
 		containers: make(map[string]*container),
 	}
 
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	src, err := ioutil.TempDir(tmpDir, "src")
+	assert.NoError(t, err)
+
+	dest, err := ioutil.TempDir(tmpDir, "dest")
+	assert.NoError(t, err)
+
+	emptyDir, err := ioutil.TempDir(tmpDir, "empty")
+	assert.NoError(t, err)
+
+	err = s.removeSandboxStorage(emptyDir)
+	assert.Error(t, err, "expect failure as directory is not a mountpoint")
+
+	err = s.removeSandboxStorage("")
+	assert.Error(t, err)
+
+	invalidDir := filepath.Join(emptyDir, "invalid")
+
+	err = s.removeSandboxStorage(invalidDir)
+	assert.Error(t, err)
+
+	// Now, create a double mount as this guarantees the directory cannot
+	// be deleted after the first unmount
+	for range []int{0, 1} {
+		err = bindMount(src, dest)
+		assert.NoError(t, err)
+	}
+
+	err = s.removeSandboxStorage(dest)
+	assert.Error(t, err, "expect fail as deletion cannot happen due to the second mount")
+
+	// This time it should work as the previous two calls have undone the double mount.
+	err = s.removeSandboxStorage(dest)
+	assert.NoError(t, err)
+
 	s.storages = make(map[string]*sandboxStorage)
-	err := s.removeSandboxStorage("/tmp/testEphePath/")
+	err = s.removeSandboxStorage("/tmp/testEphePath/")
 
 	assert.Error(t, err, "Should fail because sandbox storage doesn't exist")
 }
+
 func TestUnsetAndRemoveSandboxStorage(t *testing.T) {
+	skipUnlessRoot(t)
+
 	s := &sandbox{
 		containers: make(map[string]*container),
+		storages:   make(map[string]*sandboxStorage),
 	}
 
-	s.storages = make(map[string]*sandboxStorage)
-	err := s.unsetAndRemoveSandboxStorage("/tmp/testEphePath/")
+	path := "/tmp/testEphePath"
+	err := s.unsetAndRemoveSandboxStorage(path)
 
 	assert.Error(t, err, "Should fail because sandbox storage doesn't exist")
+
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	src, err := ioutil.TempDir(tmpDir, "src")
+	assert.NoError(t, err)
+
+	dest, err := ioutil.TempDir(tmpDir, "dest")
+	assert.NoError(t, err)
+
+	err = bindMount(src, dest)
+	assert.NoError(t, err)
+
+	newPath := s.setSandboxStorage(dest)
+	assert.True(t, newPath)
+
+	err = s.unsetAndRemoveSandboxStorage(dest)
+	assert.NoError(t, err)
+
+	// Create another directory
+	dir, err := ioutil.TempDir(tmpDir, "dir")
+	assert.NoError(t, err)
+
+	// Register it
+	newPath = s.setSandboxStorage(dir)
+	assert.True(t, newPath)
+
+	// Now, delete the directory to ensure the following call fails
+	err = os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	err = s.unsetAndRemoveSandboxStorage(dir)
+	assert.Error(t, err, "should fail as path has been deleted")
 }
 
 func TestUnSetSandboxStorage(t *testing.T) {
@@ -342,7 +434,7 @@ func TestDeleteContainer(t *testing.T) {
 
 func TestGetProcessFromSandbox(t *testing.T) {
 	s := &sandbox{
-		running:    true,
+		running:    false,
 		containers: make(map[string]*container),
 	}
 
@@ -357,6 +449,17 @@ func TestGetProcessFromSandbox(t *testing.T) {
 
 	c.processes[testExecID] = p
 	s.containers[testContainerID] = c
+
+	_, _, err := s.getProcess(testContainerID, testExecID)
+	assert.Error(t, err, "sandbox not running")
+
+	s.running = true
+
+	_, _, err = s.getProcess("invalidCID", testExecID)
+	assert.Error(t, err, "invalid container ID")
+
+	_, _, err = s.getProcess(testContainerID, "invalidExecID")
+	assert.Error(t, err, "invalid exec ID")
 
 	proc, _, err := s.getProcess(testContainerID, testExecID)
 	assert.Nil(t, err, "%v", err)
@@ -427,6 +530,38 @@ func TestMountToRootfs(t *testing.T) {
 	}
 }
 
+func TestMountToRootfsFailed(t *testing.T) {
+	assert := assert.New(t)
+
+	if os.Geteuid() == 0 {
+		t.Skip("need non-root")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	existingDir := filepath.Join(tmpDir, "exists")
+	err = os.Mkdir(existingDir, 0750)
+	assert.NoError(err)
+
+	dir := filepath.Join(tmpDir, "dir")
+
+	mounts := []initMount{
+		{"", "", "", []string{}},
+		{"", "", existingDir, []string{}},
+		{"", "", dir, []string{}},
+	}
+
+	for i, m := range mounts {
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, m)
+
+		err := mountToRootfs(m)
+		assert.Error(err, msg)
+	}
+
+}
+
 func TestGetCgroupMountsFailed(t *testing.T) {
 	cgprocDir, err := ioutil.TempDir("", "proc-cgroup")
 	assert.Nil(t, err, "%v", err)
@@ -489,6 +624,9 @@ func TestAddGuestHooks(t *testing.T) {
 	s.scanGuestHooks(hookPath)
 	assert.False(s.guestHooksPresent)
 
+	// No test to perform but this does check the function doesn't panic.
+	s.addGuestHooks(nil)
+
 	spec := &specs.Spec{}
 	s.addGuestHooks(spec)
 	assert.True(len(spec.Hooks.Poststop) == 0)
@@ -504,6 +642,118 @@ func TestAddGuestHooks(t *testing.T) {
 	s.addGuestHooks(spec)
 	assert.True(len(spec.Hooks.Poststop) == 1)
 	assert.True(strings.Contains(spec.Hooks.Poststop[0].Path, "executable"))
+}
+
+type myPostStopHook struct {
+}
+
+const hookErrorMsg = "hook always fails"
+
+func (h *myPostStopHook) Run(_ *specs.State) error {
+	return errors.New(hookErrorMsg)
+}
+
+func TestContainerRemoveContainer(t *testing.T) {
+	skipUnlessRoot(t)
+
+	assert := assert.New(t)
+
+	cid := "foo"
+
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	containerPath := filepath.Join(dir, "container")
+
+	invalidMountDir := filepath.Join(dir, "bad-mount-dir")
+
+	containerFactory, err := libcontainer.New(containerPath)
+	assert.NoError(err)
+
+	spec := &specs.Spec{
+		Root: &specs.Root{
+			Path:     containerPath,
+			Readonly: false,
+		},
+	}
+
+	hooks := &configs.Hooks{
+		Poststop: []configs.Hook{
+			&myPostStopHook{},
+		},
+	}
+
+	mounts := []string{invalidMountDir}
+
+	type testData struct {
+		withBadMount bool
+		withBadHook  bool
+		expectError  bool
+	}
+
+	data := []testData{
+		{false, false, false},
+		{true, false, true},
+		{false, true, true},
+		{true, true, true},
+	}
+
+	for i, d := range data {
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
+			CgroupName:   cid,
+			NoNewKeyring: true,
+			Spec:         spec,
+			NoPivotRoot:  true,
+		})
+		assert.NoError(err, msg)
+
+		if d.withBadHook {
+			config.Hooks = hooks
+		}
+
+		libContainerContainer, err := containerFactory.Create(cid, config)
+		assert.NoError(err, msg)
+
+		c := container{
+			ctx:       context.Background(),
+			id:        cid,
+			processes: make(map[string]*process),
+			container: libContainerContainer,
+		}
+
+		if d.withBadMount {
+			c.mounts = mounts
+		}
+
+		err = c.removeContainer()
+		if d.expectError {
+			assert.Error(err, msg)
+
+			if d.withBadHook {
+				assert.Equal(err.Error(), hookErrorMsg, msg)
+			}
+
+			continue
+		}
+
+		assert.NoError(err, msg)
+	}
+}
+
+func TestGetGRPCContext(t *testing.T) {
+	assert := assert.New(t)
+
+	grpcContext = nil
+	ctx := getGRPCContext()
+	assert.NotNil(ctx)
+
+	grpcContext = context.Background()
+	ctx = getGRPCContext()
+	assert.NotNil(ctx)
+	assert.Equal(ctx, grpcContext)
 }
 
 func TestGetMemory(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -333,3 +333,36 @@ func TestParseCmdlineOptionsVsock(t *testing.T) {
 		assert.Equal(commCh, d.expectedCommCh)
 	}
 }
+
+func TestParseCmdlineOptionDebugConsole(t *testing.T) {
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	type testData struct {
+		option                    string
+		expectDebugConsoleEnabled bool
+	}
+
+	data := []testData{
+		{"", false},
+		{"debug_console", false},
+		{"debug_console=true", false},
+		{"debug_console=1", false},
+
+		{"agent.debug_console", true},
+	}
+
+	for i, d := range data {
+		debugConsole = false
+
+		err := a.parseCmdlineOption(d.option)
+		assert.NoError(err)
+
+		if !d.expectDebugConsoleEnabled {
+			continue
+		}
+
+		assert.True(debugConsole, "test %d (%+v)", i, d)
+	}
+}

--- a/device.go
+++ b/device.go
@@ -8,16 +8,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/kata-containers/agent/pkg/uevent"
 	pb "github.com/kata-containers/agent/protocols/grpc"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -59,9 +56,7 @@ var (
 	// is always 0.
 	scsiHostChannel = "0:0:"
 	sysClassPrefix  = sysfsDir + "/class"
-	scsiDiskPrefix  = filepath.Join(sysClassPrefix, "scsi_disk", scsiHostChannel)
 	scsiBlockSuffix = "block"
-	scsiDiskSuffix  = filepath.Join("/device", scsiBlockSuffix)
 	scsiHostPath    = filepath.Join(sysClassPrefix, "scsi_host")
 )
 
@@ -121,32 +116,20 @@ func getDevicePCIAddressImpl(pciID string) (string, error) {
 	return bridgeDevicePCIAddr, nil
 }
 
-func getPCIDeviceNameImpl(s *sandbox, pciID string) (string, error) {
-	pciAddr, err := getDevicePCIAddress(pciID)
-	if err != nil {
-		return "", err
-	}
-
+func getDeviceName(s *sandbox, devID string) (string, error) {
 	var devName string
 	var notifyChan chan string
 
-	fieldLogger := agentLog.WithField("pciID", pciID)
+	fieldLogger := agentLog.WithField("devID", devID)
 
-	// Check if the PCI identifier is in PCI device map.
+	// Check if the dev identifier is in PCI device map.
 	s.Lock()
 	for key, value := range s.pciDeviceMap {
-		if strings.Contains(key, pciAddr) {
+		if strings.Contains(key, devID) {
 			devName = value
-			fieldLogger.Info("Device found in pci device map")
+			fieldLogger.Infof("Device: %s found in pci device map", devID)
 			break
 		}
-	}
-
-	// Rescan pci bus if we need to wait for a new pci device
-	if err = rescanPciBus(); err != nil {
-		fieldLogger.WithError(err).Error("Failed to scan pci bus")
-		s.Unlock()
-		return "", err
 	}
 
 	// If device is not found in the device map, hotplug event has not
@@ -156,26 +139,43 @@ func getPCIDeviceNameImpl(s *sandbox, pciID string) (string, error) {
 	// global udev listener.
 	if devName == "" {
 		notifyChan = make(chan string, 1)
-		s.deviceWatchers[pciAddr] = notifyChan
+		s.deviceWatchers[devID] = notifyChan
 	}
 	s.Unlock()
 
 	if devName == "" {
-		fieldLogger.Info("Waiting on channel for device notification")
+		fieldLogger.Infof("Waiting on channel for device: %s notification", devID)
 		select {
 		case devName = <-notifyChan:
 		case <-time.After(time.Duration(timeoutHotplug) * time.Second):
 			s.Lock()
-			delete(s.deviceWatchers, pciAddr)
+			delete(s.deviceWatchers, devID)
 			s.Unlock()
 
 			return "", grpcStatus.Errorf(codes.DeadlineExceeded,
 				"Timeout reached after %ds waiting for device %s",
-				timeoutHotplug, pciAddr)
+				timeoutHotplug, devID)
 		}
 	}
 
 	return filepath.Join(systemDevPath, devName), nil
+}
+
+func getPCIDeviceNameImpl(s *sandbox, pciID string) (string, error) {
+	pciAddr, err := getDevicePCIAddress(pciID)
+	if err != nil {
+		return "", err
+	}
+
+	fieldLogger := agentLog.WithField("pciAddr", pciAddr)
+
+	// Rescan pci bus if we need to wait for a new pci device
+	if err = rescanPciBus(); err != nil {
+		fieldLogger.WithError(err).Error("Failed to scan pci bus")
+		return "", err
+	}
+
+	return getDeviceName(s, pciAddr)
 }
 
 // device.Id should be the predicted device name (vda, vdb, ...)
@@ -205,7 +205,7 @@ func virtioBlkDeviceHandler(_ context.Context, device pb.Device, spec *pb.Spec, 
 // device.Id should be the SCSI address of the disk in the format "scsiID:lunID"
 func virtioSCSIDeviceHandler(ctx context.Context, device pb.Device, spec *pb.Spec, s *sandbox) error {
 	// Retrieve the device path from SCSI address.
-	devPath, err := getSCSIDevPath(ctx, device.Id)
+	devPath, err := getSCSIDevPath(s, device.Id)
 	if err != nil {
 		return err
 	}
@@ -292,87 +292,6 @@ func updateSpecDeviceList(device pb.Device, spec *pb.Spec) error {
 		device.VmPath)
 }
 
-type checkUeventCb func(uEv *uevent.Uevent) bool
-
-func waitForDevice(ctx context.Context, devicePath, deviceName string, checkUevent checkUeventCb) error {
-	if devicePath == "" {
-		return errors.New("need device path")
-	}
-
-	if deviceName == "" {
-		return errors.New("need device name")
-	}
-
-	if checkUevent == nil {
-		return errors.New("invalid uevent handler")
-	}
-
-	uEvHandler, err := uevent.NewHandler()
-	if err != nil {
-		return err
-	}
-	defer uEvHandler.Close()
-
-	fieldLogger := agentLog.WithField("device", deviceName)
-
-	// Check if the device already exists.
-	if _, err := os.Stat(devicePath); err == nil {
-		fieldLogger.Info("Device already hotplugged, quit listening")
-		return nil
-	}
-
-	fieldLogger.Info("Started listening for uevents for device hotplug")
-
-	// Channel to signal when desired uevent has been received.
-	done := make(chan bool)
-
-	go func() {
-		// This loop will be either ended if the hotplugged device is
-		// found by listening to the netlink socket, or it will end
-		// after the function returns and the uevent handler is closed.
-	outer:
-		for {
-			select {
-			case <-ctx.Done():
-				break
-			default:
-
-				uEv, err := uEvHandler.Read()
-				if err != nil {
-					fieldLogger.Error(err)
-					continue
-				}
-
-				fieldLogger = fieldLogger.WithFields(logrus.Fields{
-					"uevent-action":    uEv.Action,
-					"uevent-devpath":   uEv.DevPath,
-					"uevent-subsystem": uEv.SubSystem,
-					"uevent-seqnum":    uEv.SeqNum,
-				})
-
-				fieldLogger.Info("Got uevent")
-
-				if checkUevent(uEv) {
-					fieldLogger.Info("Hotplug event received")
-					break outer
-				}
-			}
-		}
-
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Duration(timeoutHotplug) * time.Second):
-		return grpcStatus.Errorf(codes.DeadlineExceeded,
-			"Timeout reached after %ds waiting for device %s",
-			timeoutHotplug, deviceName)
-	}
-
-	return nil
-}
-
 // scanSCSIBus scans SCSI bus for the given SCSI address(SCSI-Id and LUN)
 func scanSCSIBusImpl(scsiAddr string) error {
 	files, err := ioutil.ReadDir(scsiHostPath)
@@ -402,49 +321,17 @@ func scanSCSIBusImpl(scsiAddr string) error {
 	return nil
 }
 
-// findSCSIDisk finds the SCSI disk name associated with the given SCSI path.
-// This approach eliminates the need to predict the disk name on the host side,
-// but we do need to rescan SCSI bus for this.
-func findSCSIDisk(scsiPath string) (string, error) {
-	files, err := ioutil.ReadDir(scsiPath)
-	if err != nil {
-		return "", err
-	}
-
-	if len(files) != 1 {
-		return "", grpcStatus.Errorf(codes.Internal,
-			"Expecting a single SCSI device, found %v",
-			files)
-	}
-
-	return files[0].Name(), nil
-}
-
 // getSCSIDevPathImpl scans SCSI bus looking for the provided SCSI address, then
 // it waits for the SCSI disk to become available and returns the device path
 // associated with the disk.
-func getSCSIDevPathImpl(ctx context.Context, scsiAddr string) (string, error) {
+func getSCSIDevPathImpl(s *sandbox, scsiAddr string) (string, error) {
 	if err := scanSCSIBus(scsiAddr); err != nil {
 		return "", err
 	}
 
-	devPath := filepath.Join(scsiDiskPrefix+scsiAddr, scsiDiskSuffix)
+	devPath := filepath.Join(scsiHostChannel+scsiAddr, scsiBlockSuffix)
 
-	checkUevent := func(uEv *uevent.Uevent) bool {
-		devSubPath := filepath.Join(scsiHostChannel+scsiAddr, scsiBlockSuffix)
-		return (uEv.Action == "add" &&
-			strings.Contains(uEv.DevPath, devSubPath))
-	}
-	if err := waitForDevice(ctx, devPath, scsiAddr, checkUevent); err != nil {
-		return "", err
-	}
-
-	scsiDiskName, err := findSCSIDisk(devPath)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(devPrefix, scsiDiskName), nil
+	return getDeviceName(s, devPath)
 }
 
 func addDevices(ctx context.Context, devices []*pb.Device, spec *pb.Spec, s *sandbox) error {

--- a/device.go
+++ b/device.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -288,6 +289,18 @@ func updateSpecDeviceList(device pb.Device, spec *pb.Spec) error {
 type checkUeventCb func(uEv *uevent.Uevent) bool
 
 func waitForDevice(devicePath, deviceName string, checkUevent checkUeventCb) error {
+	if devicePath == "" {
+		return errors.New("need device path")
+	}
+
+	if deviceName == "" {
+		return errors.New("need device name")
+	}
+
+	if checkUevent == nil {
+		return errors.New("invalid uevent handler")
+	}
+
 	uEvHandler, err := uevent.NewHandler()
 	if err != nil {
 		return err

--- a/grpc.go
+++ b/grpc.go
@@ -619,7 +619,7 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 	// updates the devices listed in the OCI spec, so that they actually
 	// match real devices inside the VM. This step is necessary since we
 	// cannot predict everything from the caller.
-	if err = addDevices(req.Devices, req.OCI, a.sandbox); err != nil {
+	if err = addDevices(ctx, req.Devices, req.OCI, a.sandbox); err != nil {
 		return emptyResp, err
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -252,7 +252,13 @@ func localStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (str
 			mode = os.FileMode(m)
 		}
 
-		return "", os.MkdirAll(storage.MountPoint, mode)
+		if err := os.MkdirAll(storage.MountPoint, mode); err != nil {
+			return "", err
+		}
+
+		// We chmod the permissions for the mount point, as we can't rely on os.MkdirAll to set the
+		// desired permissions.
+		return "", os.Chmod(storage.MountPoint, mode)
 	}
 	return "", nil
 }

--- a/mount.go
+++ b/mount.go
@@ -23,12 +23,11 @@ import (
 )
 
 const (
-	type9pFs       = "9p"
-	typeVirtioFS   = "virtio_fs"
-	typeTmpFs      = "tmpfs"
-	devPrefix      = "/dev/"
-	timeoutHotplug = 3
-	mountPerm      = os.FileMode(0755)
+	type9pFs     = "9p"
+	typeVirtioFS = "virtio_fs"
+	typeTmpFs    = "tmpfs"
+	devPrefix    = "/dev/"
+	mountPerm    = os.FileMode(0755)
 )
 
 var flagList = map[string]int{
@@ -202,7 +201,7 @@ func removeMounts(mounts []string) error {
 
 // storageHandler is the type of callback to be defined to handle every
 // type of storage driver.
-type storageHandler func(storage pb.Storage, s *sandbox) (string, error)
+type storageHandler func(ctx context.Context, storage pb.Storage, s *sandbox) (string, error)
 
 // storageHandlerList lists the supported drivers.
 var storageHandlerList = map[string]storageHandler{
@@ -215,7 +214,7 @@ var storageHandlerList = map[string]storageHandler{
 	driverLocalType:     localStorageHandler,
 }
 
-func ephemeralStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func ephemeralStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	s.Lock()
 	defer s.Unlock()
 	newStorage := s.setSandboxStorage(storage.MountPoint)
@@ -230,7 +229,7 @@ func ephemeralStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
 	return "", nil
 }
 
-func localStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func localStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	s.Lock()
 	defer s.Unlock()
 	newStorage := s.setSandboxStorage(storage.MountPoint)
@@ -254,23 +253,23 @@ func localStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
 }
 
 // virtio9pStorageHandler handles the storage for 9p driver.
-func virtio9pStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func virtio9pStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	return commonStorageHandler(storage)
 }
 
 // virtioMmioBlkStorageHandler handles the storage for mmio blk driver.
-func virtioMmioBlkStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func virtioMmioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	//The source path is VmPath
 	return commonStorageHandler(storage)
 }
 
 // virtioFSStorageHandler handles the storage for virtio-fs.
-func virtioFSStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func virtioFSStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	return commonStorageHandler(storage)
 }
 
 // virtioBlkStorageHandler handles the storage for blk driver.
-func virtioBlkStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func virtioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 
 	// If hot-plugged, get the device node path based on the PCI address else
 	// use the virt path provided in Storage Source
@@ -298,9 +297,9 @@ func virtioBlkStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
 }
 
 // virtioSCSIStorageHandler handles the storage for scsi driver.
-func virtioSCSIStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
+func virtioSCSIStorageHandler(ctx context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	// Retrieve the device path from SCSI address.
-	devPath, err := getSCSIDevPath(storage.Source)
+	devPath, err := getSCSIDevPath(ctx, storage.Source)
 	if err != nil {
 		return "", err
 	}
@@ -367,7 +366,7 @@ func addStorages(ctx context.Context, storages []*pb.Storage, s *sandbox) (mount
 		// the handler interface but also to avoid having to add trace
 		// code to each driver.
 		handlerSpan, _ := trace(ctx, "mount", storage.Driver)
-		mountPoint, err := devHandler(*storage, s)
+		mountPoint, err := devHandler(ctx, *storage, s)
 		handlerSpan.Finish()
 
 		if _, ok := s.storages[storage.MountPoint]; ok {

--- a/mount.go
+++ b/mount.go
@@ -282,7 +282,7 @@ func virtioBlkStorageHandler(storage pb.Storage, s *sandbox) (string, error) {
 		}
 		// Make sure the virt path is valid
 		if FileInfo.Mode()&os.ModeDevice == 0 {
-			return "", err
+			return "", fmt.Errorf("invalid device %s", storage.Source)
 		}
 
 	} else {

--- a/mount.go
+++ b/mount.go
@@ -158,7 +158,7 @@ func ensureDestinationExists(source, destination string, fsType string) error {
 	return nil
 }
 
-func parseMountFlagsAndOptions(optionList []string) (int, string, error) {
+func parseMountFlagsAndOptions(optionList []string) (int, string) {
 	var (
 		flags   int
 		options []string
@@ -174,7 +174,7 @@ func parseMountFlagsAndOptions(optionList []string) (int, string, error) {
 		options = append(options, opt)
 	}
 
-	return flags, strings.Join(options, ","), nil
+	return flags, strings.Join(options, ",")
 }
 
 func parseOptions(optionList []string) map[string]string {
@@ -320,10 +320,7 @@ func commonStorageHandler(storage pb.Storage) (string, error) {
 
 // mountStorage performs the mount described by the storage structure.
 func mountStorage(storage pb.Storage) error {
-	flags, options, err := parseMountFlagsAndOptions(storage.Options)
-	if err != nil {
-		return err
-	}
+	flags, options := parseMountFlagsAndOptions(storage.Options)
 
 	return mount(storage.Source, storage.MountPoint, storage.Fstype, flags, options)
 }

--- a/mount.go
+++ b/mount.go
@@ -30,7 +30,6 @@ const (
 	typeVirtioFS   = "virtio_fs"
 	typeRootfs     = "rootfs"
 	typeTmpFs      = "tmpfs"
-	devPrefix      = "/dev/"
 	procMountStats = "/proc/self/mountstats"
 	mountPerm      = os.FileMode(0755)
 )
@@ -310,7 +309,7 @@ func virtioBlkStorageHandler(_ context.Context, storage pb.Storage, s *sandbox) 
 // virtioSCSIStorageHandler handles the storage for scsi driver.
 func virtioSCSIStorageHandler(ctx context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	// Retrieve the device path from SCSI address.
-	devPath, err := getSCSIDevPath(ctx, storage.Source)
+	devPath, err := getSCSIDevPath(s, storage.Source)
 	if err != nil {
 		return "", err
 	}

--- a/mount_test.go
+++ b/mount_test.go
@@ -605,3 +605,46 @@ func TestMountEnsureDestinationExists(t *testing.T) {
 		}
 	}
 }
+
+func TestGetMountFSType(t *testing.T) {
+	assert := assert.New(t)
+
+	// Type used to hold function parameters and expected results.
+	type testData struct {
+		param1         string
+		expectedResult string
+		expectError    bool
+	}
+
+	// List of tests to run including the expected results
+	data := []testData{
+		// failure scenarios
+		{"/thisPathShouldNotBeAMountPoint", "", true},
+
+		// success scenarios
+		{"/proc", "proc", false},
+		{"/sys", "sysfs", false},
+		{"/run", "tmpfs", false},
+	}
+
+	// Run the tests
+	for i, d := range data {
+		// Create a test-specific string that is added to each assert
+		// call. It will be displayed if any assert test fails.
+		msg := fmt.Sprintf("test[%d]: %+v", i, d)
+
+		// Call the function under test
+		result, err := getMountFSType(d.param1)
+
+		if d.expectError {
+			assert.Error(err, msg)
+
+			// If an error is expected, there is no point
+			// performing additional checks.
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.Equal(d.expectedResult, result, msg)
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -44,8 +44,16 @@ func TestEphemeralStorageHandlerSuccessful(t *testing.T) {
 	storage.Fstype = typeTmpFs
 	storage.Source = typeTmpFs
 	sbs := make(map[string]*sandboxStorage)
-	_, err = ephemeralStorageHandler(storage, &sandbox{storages: sbs})
+
+	ctx := context.Background()
+
+	_, err = ephemeralStorageHandler(ctx, storage, &sandbox{storages: sbs})
 	assert.Nil(t, err, "ephemeralStorageHandler() failed: %v", err)
+
+	// Try again. This time the storage won't be new
+	result, err := ephemeralStorageHandler(ctx, storage, &sandbox{storages: sbs})
+	assert.NoError(t, err)
+	assert.Empty(t, result)
 }
 
 func TestLocalStorageHandlerSuccessful(t *testing.T) {
@@ -59,8 +67,16 @@ func TestLocalStorageHandlerSuccessful(t *testing.T) {
 	defer os.RemoveAll(storage.MountPoint)
 
 	sbs := make(map[string]*sandboxStorage)
-	_, err = localStorageHandler(storage, &sandbox{storages: sbs})
+
+	ctx := context.Background()
+
+	_, err = localStorageHandler(ctx, storage, &sandbox{storages: sbs})
 	assert.Nil(t, err, "localStorageHandler() failed: %v", err)
+
+	// Try again. This time the storage won't be new
+	result, err := localStorageHandler(ctx, storage, &sandbox{storages: sbs})
+	assert.NoError(t, err)
+	assert.Empty(t, result)
 }
 
 func TestLocalStorageHandlerPermModeSuccessful(t *testing.T) {
@@ -78,8 +94,10 @@ func TestLocalStorageHandlerPermModeSuccessful(t *testing.T) {
 		"mode=0400",
 	}
 
+	ctx := context.Background()
+
 	sbs := make(map[string]*sandboxStorage)
-	_, err = localStorageHandler(storage, &sandbox{storages: sbs})
+	_, err = localStorageHandler(ctx, storage, &sandbox{storages: sbs})
 	assert.Nil(t, err, "localStorageHandler() failed: %v", err)
 
 	// Check the mode of the mountpoint
@@ -104,7 +122,10 @@ func TestLocalStorageHandlerPermModeFailure(t *testing.T) {
 	}
 
 	sbs := make(map[string]*sandboxStorage)
-	_, err = localStorageHandler(storage, &sandbox{storages: sbs})
+
+	ctx := context.Background()
+
+	_, err = localStorageHandler(ctx, storage, &sandbox{storages: sbs})
 	assert.NotNil(t, err, "localStorageHandler() should have failed")
 }
 
@@ -121,7 +142,9 @@ func TestVirtio9pStorageHandlerSuccessful(t *testing.T) {
 	storage.Fstype = "bind"
 	storage.Options = []string{"rbind"}
 
-	_, err = virtio9pStorageHandler(storage, &sandbox{})
+	ctx := context.Background()
+
+	_, err = virtio9pStorageHandler(ctx, storage, &sandbox{})
 	assert.Nil(t, err, "storage9pDriverHandler() failed: %v", err)
 }
 
@@ -132,21 +155,26 @@ func TestVirtioBlkStoragePathFailure(t *testing.T) {
 		Source: "/home/developer/test",
 	}
 
-	_, err := virtioBlkStorageHandler(storage, s)
-	agentLog.WithError(err).Error("virtioBlkStorageHandler error")
+	ctx := context.Background()
+
+	_, err := virtioBlkStorageHandler(ctx, storage, s)
 	assert.NotNil(t, err, "virtioBlkStorageHandler() should have failed")
 }
 
 func TestVirtioBlkStorageDeviceFailure(t *testing.T) {
 	s := &sandbox{}
 
-	storage := pb.Storage{
-		Source: "/dev/foo",
-	}
+	for i, source := range []string{"/dev/foo", "/dev/disk"} {
+		msg := fmt.Sprintf("source[%d]: %+v\n", i, source)
+		storage := pb.Storage{
+			Source: source,
+		}
 
-	_, err := virtioBlkStorageHandler(storage, s)
-	agentLog.WithError(err).Error("virtioBlkStorageHandler error")
-	assert.NotNil(t, err, "virtioBlkStorageHandler() should have failed")
+		ctx := context.Background()
+
+		_, err := virtioBlkStorageHandler(ctx, storage, s)
+		assert.NotNil(t, err, fmt.Sprintf("%s: virtioBlkStorageHandler() should have failed", msg))
+	}
 }
 
 func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
@@ -199,9 +227,43 @@ func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
 	storage.Fstype = "bind"
 	storage.Options = []string{"rbind"}
 
+	ctx := context.Background()
+
 	systemDevPath = ""
-	_, err = virtioBlkStorageHandler(storage, s)
+	_, err = virtioBlkStorageHandler(ctx, storage, s)
 	assert.Nil(t, err, "storageBlockStorageDriverHandler() failed: %v", err)
+}
+
+func TestVirtioSCSIStorageHandlerFailure(t *testing.T) {
+	skipIfRoot(t)
+
+	assert := assert.New(t)
+
+	const expectedDevPath = "/dev/some/where"
+
+	savedSCSIDevPathFunc := getSCSIDevPath
+	getSCSIDevPath = func(_ context.Context, scsiAddr string) (string, error) {
+		return expectedDevPath, nil
+	}
+
+	defer func() {
+		getSCSIDevPath = savedSCSIDevPathFunc
+	}()
+
+	storage := pb.Storage{
+		MountPoint: "/new/mount/point",
+	}
+
+	sb := sandbox{
+		storages: make(map[string]*sandboxStorage),
+	}
+
+	assert.Empty(storage.Source)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := virtioSCSIStorageHandler(ctx, storage, &sb)
+	assert.Error(err)
 }
 
 func testAddStoragesSuccessful(t *testing.T, storages []*pb.Storage) {
@@ -223,19 +285,25 @@ func TestAddStoragesNilStoragesSuccessful(t *testing.T) {
 	testAddStoragesSuccessful(t, storages)
 }
 
-func noopStorageHandlerReturnNil(storage pb.Storage, s *sandbox) (string, error) {
+func noopStorageHandlerReturnNil(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	return "", nil
 }
 
-func noopStorageHandlerReturnError(storage pb.Storage, s *sandbox) (string, error) {
+func noopStorageHandlerReturnError(_ context.Context, storage pb.Storage, s *sandbox) (string, error) {
 	return "", fmt.Errorf("Noop handler failure")
 }
 
 func TestAddStoragesNoopHandlerSuccessful(t *testing.T) {
 	noopHandlerTag := "noop"
+	savedStorageHandlerList := storageHandlerList
+
 	storageHandlerList = map[string]storageHandler{
 		noopHandlerTag: noopStorageHandlerReturnNil,
 	}
+
+	defer func() {
+		storageHandlerList = savedStorageHandlerList
+	}()
 
 	storages := []*pb.Storage{
 		{
@@ -252,7 +320,13 @@ func testAddStoragesFailure(t *testing.T, storages []*pb.Storage) {
 }
 
 func TestAddStoragesUnknownHandlerFailure(t *testing.T) {
+	savedStorageHandlerList := storageHandlerList
+
 	storageHandlerList = map[string]storageHandler{}
+
+	defer func() {
+		storageHandlerList = savedStorageHandlerList
+	}()
 
 	storages := []*pb.Storage{
 		{
@@ -265,9 +339,16 @@ func TestAddStoragesUnknownHandlerFailure(t *testing.T) {
 
 func TestAddStoragesNoopHandlerFailure(t *testing.T) {
 	noopHandlerTag := "noop"
+
+	savedStorageHandlerList := storageHandlerList
+
 	storageHandlerList = map[string]storageHandler{
 		noopHandlerTag: noopStorageHandlerReturnError,
 	}
+
+	defer func() {
+		storageHandlerList = savedStorageHandlerList
+	}()
 
 	storages := []*pb.Storage{
 		{
@@ -280,6 +361,43 @@ func TestAddStoragesNoopHandlerFailure(t *testing.T) {
 
 func TestMount(t *testing.T) {
 	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	dir := filepath.Join(tmpdir, "dir")
+
+	// make directory unreadable by non-root user
+	err = os.Mkdir(dir, os.FileMode(0000))
+	assert.NoError(err)
+
+	subdir := filepath.Join(dir, "sub1", "sub2")
+
+	validSubdir := filepath.Join(tmpdir, "valid-subdir")
+
+	existsFile := filepath.Join(tmpdir, "exists-file")
+	err = createEmptyFile(existsFile)
+	assert.NoError(err)
+
+	existingNonCreatableFile := filepath.Join(tmpdir, "uncreatable")
+	err = createEmptyFileWithPerms(existingNonCreatableFile, 0000)
+	assert.NoError(err)
+
+	// We only test error scenarios
+	skipIfRoot(t)
+
+	symLinkName := filepath.Join(tmpdir, "sym-link-name")
+	symLinkDest := filepath.Join(tmpdir, "sym-link-dest")
+
+	//err = createEmptyFile(symLinkDest)
+	//assert.NoError(err)
+
+	err = os.Symlink(symLinkDest, symLinkName)
+	assert.NoError(err)
+
+	// Now, break the symlink
+	////os.Remove(symLinkDest)
 
 	type testData struct {
 		source      string
@@ -296,6 +414,14 @@ func TestMount(t *testing.T) {
 		{"", "/foo", "9p", 0, "", true},
 		{"proc", "", "9p", 0, "", true},
 		{"proc", "/proc", "", 0, "", true},
+		{"proc", "", "virtio_fs", 0, "", true},
+		{"proc", subdir, "virtio_fs", 0, "", true},
+		{"proc", subdir, "foo", 0, "", true},
+		{symLinkName, symLinkDest, "moo", 0, "", true},
+		{existsFile, existingNonCreatableFile, "bind", 0, "", true},
+		{"tmpfs", validSubdir, "tmpfs", 0, "", true},
+		{"proc", validSubdir, "9p", 0, "", true},
+		{"proc", validSubdir, "virtio_fs", 0, "", true},
 	}
 
 	for i, d := range data {
@@ -346,5 +472,45 @@ func TestMountParseMountFlagsAndOptions(t *testing.T) {
 		assert.Equal(d.expectedFlags, flags, msg)
 		assert.Equal(d.expectedOptions, options, msg)
 
+	}
+}
+
+func TestCommonStorageHandler(t *testing.T) {
+	skipIfRoot(t)
+
+	assert := assert.New(t)
+
+	storage := pb.Storage{}
+
+	mountPoint, err := commonStorageHandler(storage)
+	assert.Empty(mountPoint)
+	assert.Error(err)
+
+}
+
+func TestStorageHandlers(t *testing.T) {
+	skipIfRoot(t)
+
+	assert := assert.New(t)
+
+	for name, handler := range storageHandlerList {
+		msg := fmt.Sprintf("test: storage handler: %s", name)
+
+		fmt.Println(msg)
+
+		storage := pb.Storage{
+			MountPoint: "/new/mount/point",
+		}
+
+		sb := sandbox{
+			storages: make(map[string]*sandboxStorage),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		mountPoint, err := handler(ctx, storage, &sb)
+
+		assert.Empty(mountPoint, msg)
+		assert.Error(err, msg)
+		cancel()
 	}
 }

--- a/mount_test.go
+++ b/mount_test.go
@@ -273,7 +273,7 @@ func TestVirtioSCSIStorageHandlerFailure(t *testing.T) {
 	const expectedDevPath = "/dev/some/where"
 
 	savedSCSIDevPathFunc := getSCSIDevPath
-	getSCSIDevPath = func(_ context.Context, scsiAddr string) (string, error) {
+	getSCSIDevPath = func(s *sandbox, scsiAddr string) (string, error) {
 		return expectedDevPath, nil
 	}
 

--- a/mount_test.go
+++ b/mount_test.go
@@ -308,3 +308,43 @@ func TestMount(t *testing.T) {
 		}
 	}
 }
+
+func TestMountParseMountFlagsAndOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		options []string
+
+		expectedFlags   int
+		expectedOptions string
+	}
+
+	// Start with some basic tests
+	data := []testData{
+		{[]string{}, 0, ""},
+		{[]string{"moo"}, 0, "moo"},
+		{[]string{"moo", "foo"}, 0, "moo,foo"},
+		{[]string{"foo", "moo"}, 0, "foo,moo"},
+	}
+
+	// Add the expected flag handling tests
+	for name, value := range flagList {
+		td := testData{
+			options:         []string{"foo", name, "bar"},
+			expectedFlags:   value,
+			expectedOptions: "foo,bar",
+		}
+
+		data = append(data, td)
+	}
+
+	for i, d := range data {
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		flags, options := parseMountFlagsAndOptions(d.options)
+
+		assert.Equal(d.expectedFlags, flags, msg)
+		assert.Equal(d.expectedOptions, options, msg)
+
+	}
+}


### PR DESCRIPTION
Summary of changes to add to the `stable-1.8` branch:

  177d240 (originally 006fdfe) - `device: fix the issue of failed waiting on device appeared in /dev`
  a64652a (originally 545a411) - `mount: ensure local directory storage types have the correct permissions`
  0ec5e6c (originally b1a4284) - `travis: Fix golang version`
  2a75586 (originally 4ab32a9) - `vendor: dep check fixes`
  bbb7b11 (originally cf20c9b) - `ci: Allow travis to use go install script`
  b725a88 (originally 5ffb2a6) - `agent: make NoPivotRoot config depend on `/` fs type`
  79f51ae (originally a1c9d50) - `make: install depends on $(TARGET)`
  60a20bf (originally 7c97a0a) - `agent: delete element of sandbox.deviceWatchers with right key`
  b908072 (originally 4354b24) - `tests: Add lots of new unit tests`
  bdf4ab0 (originally d4a22d1) - `device: Allow uevent handler to be stopped`
  6a11554 (originally 8eb2134) - `config: Add parseCmdlineOption test`
  5de1e58 (originally d4f205d) - `device: Add extra checks`
  f836238 (originally faa6cb0) - `mount: Fix incorrect error return`
  dd5869e (originally 2d95c36) - `mount: Add test for parseMountFlagsAndOptions`
  77ecd6f (originally 5163bab) - `console: Add debug console test`
  c6b61ce (originally d167490) - `sandbox: Remove redundant check`
  9dfb342 (originally 72fc0ad) - `mount: Improve error message`
  71e70da (originally c92715f) - `tests: Add test for getMemory`
  4f03254 (originally cd2f994) - `memory: Add extra check for memory file`
