### PR TITLE
protocols/client: support hybrid vsocks

### DIFF
--- a/protocols/client/client_test.go
+++ b/protocols/client/client_test.go
@@ -160,3 +160,20 @@ func TestNewAgentClientWithYamux(t *testing.T) {
 	mock.Stop()
 	<-waitCh
 }
+
+func TestParseGrpcHybridVSockAddr(t *testing.T) {
+	assert := assert.New(t)
+
+	a, err := parseGrpcHybridVSockAddr("/abc/xyz")
+	assert.Error(err)
+	assert.Empty(a)
+
+	a, err = parseGrpcHybridVSockAddr("sss:/abc/xyz")
+	assert.Error(err)
+	assert.Empty(a)
+
+	path := "/abc/xyz"
+	a, err = parseGrpcHybridVSockAddr(hybridVSockScheme + ":" + path)
+	assert.NoError(err)
+	assert.Equal(a, path)
+}


### PR DESCRIPTION
hybrid vsocks is a new way to communicate host and guest,
currently it's only supported by firecracker.

fixes #642

Signed-off-by: Julio Montes <julio.montes@intel.com>