### PR TITLE
CI: Make Travis call common setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,12 @@ go_import_path: github.com/kata-containers/agent
 env:
   - target_branch=$TRAVIS_BRANCH
 
-before_script:
-  - ".ci/static-checks.sh"
-
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq automake
-  - sudo apt-get install -y moreutils
+  - ".ci/setup.sh"
+
+before_script:
   - ".ci/install_go.sh"
+  - ".ci/static-checks.sh"
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make


### PR DESCRIPTION
Update the `.travis.yml` config file to call the common CI setup script.

This ensures Travis jobs have the correct set of packages installed for running all the static checks.

Fixes: #648.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>