### PR TITLE
Revert "client: remove the parameter of 'enableYamux'"

### DIFF
--- a/protocols/client/client_test.go
+++ b/protocols/client/client_test.go
@@ -91,13 +91,13 @@ func checkVersion(cli *AgentClient) error {
 	return nil
 }
 
-func agentClientTest(t *testing.T, sock string, success bool, expect string) {
+func agentClientTest(t *testing.T, sock string, success, enableYamux bool, expect string) {
 	dialTimeout := defaultDialTimeout
 	defaultDialTimeout = 1 * time.Second
 	defer func() {
 		defaultDialTimeout = dialTimeout
 	}()
-	cli, err := NewAgentClient(context.Background(), sock)
+	cli, err := NewAgentClient(context.Background(), sock, enableYamux)
 	if success {
 		assert.Nil(t, err, "Failed to create new agent client: %s", err)
 	} else if !success {
@@ -116,16 +116,17 @@ func agentClientTest(t *testing.T, sock string, success bool, expect string) {
 }
 
 func TestNewAgentClient(t *testing.T) {
-	mock, waitCh, err := startMockServer(t, true)
+	mock, waitCh, err := startMockServer(t, false)
 	assert.Nil(t, err, "failed to start mock server: %s", err)
 	defer os.Remove(mockSockAddr)
 
 	cliFunc := func(sock string, success bool, expect string) {
-		agentClientTest(t, sock, success, expect)
+		agentClientTest(t, sock, success, false, expect)
 	}
 
 	// server starts
 	<-waitCh
+	cliFunc(mockSockAddr, true, "")
 	cliFunc(unixMockAddr, true, "")
 	cliFunc(mockBadSchemeAddr, false, "Invalid scheme:")
 	cliFunc(mockBadVsockScheme, false, "Invalid vsock scheme:")
@@ -144,7 +145,7 @@ func TestNewAgentClientWithYamux(t *testing.T) {
 	defer os.Remove(mockSockAddr)
 
 	cliFunc := func(sock string, success bool, expect string) {
-		agentClientTest(t, sock, success, expect)
+		agentClientTest(t, sock, success, true, expect)
 	}
 	// server starts
 	<-waitCh


### PR DESCRIPTION
Since most of the runtime unit tests depending on unix socket without yamux, 
thus I have to revert this commit.

Reverts kata-containers/agent#660