### PR TITLE
tracing: Generate an alias for opentracing.Span

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -175,6 +175,9 @@ var logsVSockPort = uint32(0)
 // commType is used to denote the communication channel type used.
 type commType int
 
+// agentSpan is used to denote the span tracing that is being used.
+type agentSpan opentracing.Span
+
 const (
 	// virtio-serial channel
 	serialCh commType = iota
@@ -239,7 +242,7 @@ func (p *process) closePostExitFDs() {
 	}
 }
 
-func (c *container) trace(name string) (opentracing.Span, context.Context) {
+func (c *container) trace(name string) (agentSpan, context.Context) {
 	if c.ctx == nil {
 		agentLog.WithField("type", "bug").Error("trace called before context set")
 		c.ctx = context.Background()
@@ -288,7 +291,7 @@ func (c *container) getProcess(execID string) (*process, error) {
 	return proc, nil
 }
 
-func (s *sandbox) trace(name string) (opentracing.Span, context.Context) {
+func (s *sandbox) trace(name string) (agentSpan, context.Context) {
 	if s.ctx == nil {
 		agentLog.WithField("type", "bug").Error("trace called before context set")
 		s.ctx = context.Background()
@@ -1028,7 +1031,7 @@ func makeUnaryInterceptor() grpc.UnaryServerInterceptor {
 
 		grpcCall := info.FullMethod
 		var ctx context.Context
-		var span opentracing.Span
+		var span agentSpan
 
 		if tracing {
 			ctx = getGRPCContext()

--- a/tracing.go
+++ b/tracing.go
@@ -21,7 +21,7 @@ const (
 )
 
 // The first trace span
-var rootSpan opentracing.Span
+var rootSpan agentSpan
 
 // Implements jaeger-client-go.Logger interface
 type traceLogger struct {
@@ -82,7 +82,7 @@ func createTracer(name string) (opentracing.Tracer, error) {
 	return tracer, nil
 }
 
-func setupTracing(rootSpanName string) (opentracing.Span, context.Context, error) {
+func setupTracing(rootSpanName string) (agentSpan, context.Context, error) {
 	ctx := context.Background()
 
 	tracer, err := createTracer(agentName)
@@ -132,7 +132,7 @@ func stopTracing(ctx context.Context) {
 
 // trace creates a new tracing span based on the specified contex, subsystem
 // and name.
-func trace(ctx context.Context, subsystem, name string) (opentracing.Span, context.Context) {
+func trace(ctx context.Context, subsystem, name string) (agentSpan, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, name)
 
 	span.SetTag("subsystem", subsystem)


### PR DESCRIPTION
We should use an alias for opentracing.Span as this can be changed in the
future when we implement other tracing methods.

Fixes #664

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>