### PR TITLE
agent: firecracker: support debugging console

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,19 +17,20 @@ import (
 )
 
 const (
-	optionPrefix      = "agent."
-	logLevelFlag      = optionPrefix + "log"
-	logsVSockPortFlag = optionPrefix + "log_vport"
-	devModeFlag       = optionPrefix + "devmode"
-	traceModeFlag     = optionPrefix + "trace"
-	useVsockFlag      = optionPrefix + "use_vsock"
-	debugConsoleFlag  = optionPrefix + "debug_console"
-	kernelCmdlineFile = "/proc/cmdline"
-	traceModeStatic   = "static"
-	traceModeDynamic  = "dynamic"
-	traceTypeIsolated = "isolated"
-	traceTypeCollated = "collated"
-	defaultTraceType  = traceTypeIsolated
+	optionPrefix          = "agent."
+	logLevelFlag          = optionPrefix + "log"
+	logsVSockPortFlag     = optionPrefix + "log_vport"
+	devModeFlag           = optionPrefix + "devmode"
+	traceModeFlag         = optionPrefix + "trace"
+	useVsockFlag          = optionPrefix + "use_vsock"
+	debugConsoleFlag      = optionPrefix + "debug_console"
+	debugConsoleVPortFlag = optionPrefix + "debug_console_vport"
+	kernelCmdlineFile     = "/proc/cmdline"
+	traceModeStatic       = "static"
+	traceModeDynamic      = "dynamic"
+	traceTypeIsolated     = "isolated"
+	traceTypeCollated     = "collated"
+	defaultTraceType      = traceTypeIsolated
 )
 
 type agentConfig struct {
@@ -113,6 +114,13 @@ func (c *agentConfig) parseCmdlineOption(option string) error {
 			return err
 		}
 		logsVSockPort = uint32(port)
+	case debugConsoleVPortFlag:
+		port, err := strconv.ParseUint(split[valuePosition], 10, 32)
+		if err != nil {
+			return err
+		}
+		debugConsole = true
+		debugConsoleVSockPort = uint32(port)
 	case traceModeFlag:
 		switch split[valuePosition] {
 		case traceTypeIsolated:

--- a/config_test.go
+++ b/config_test.go
@@ -366,3 +366,45 @@ func TestParseCmdlineOptionDebugConsole(t *testing.T) {
 		assert.True(debugConsole, "test %d (%+v)", i, d)
 	}
 }
+
+func TestParseCmdlineOptionDebugConsoleVPort(t *testing.T) {
+	assert := assert.New(t)
+
+	a := &agentConfig{}
+
+	type testData struct {
+		option                    string
+		expectDebugConsoleEnabled bool
+		expectedError             bool
+		expectedVPort             uint32
+	}
+
+	data := []testData{
+		{"", false, false, 0},
+		{"debug_console_vport", false, false, 0},
+		{"debug_console_vport=xxx", false, false, 0},
+		{"debug_console_vport=1026", false, false, 0},
+		{debugConsoleVPortFlag + "=", false, true, 0},
+		{debugConsoleVPortFlag + "=xxxx", false, true, 0},
+		{debugConsoleVPortFlag, false, false, 0},
+		{debugConsoleVPortFlag + "=1026", false, false, 1026},
+	}
+
+	for i, d := range data {
+		debugConsole = false
+		debugConsoleVSockPort = 0
+
+		err := a.parseCmdlineOption(d.option)
+		if d.expectedError {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+		}
+
+		if d.expectDebugConsoleEnabled {
+			assert.True(debugConsole, "test %d (%+v)", i, d)
+		}
+
+		assert.Equal(debugConsoleVSockPort, d.expectedVPort)
+	}
+}


### PR DESCRIPTION
some hypervisors, like firecracker, don't have connected a unix socket to
`/dev/console` making impossible to start a debugging console.
Use vsock connection as standard input and output (std*) for the shell
process.
Add cmdline option to specify the vsock port to connect the debugging console.

fixes #666

Signed-off-by: Julio Montes <julio.montes@intel.com>