### PR TITLE
tracing: Wrapper for tracing functions

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -47,7 +47,7 @@ type channel interface {
 // If there are neither vsocks nor serial ports, an error is returned.
 func newChannel(ctx context.Context) (channel, error) {
 	span, _ := trace(ctx, "channel", "newChannel")
-	defer span.Finish()
+	defer span.finish()
 
 	var serialErr error
 	var vsockErr error
@@ -91,13 +91,13 @@ func newChannel(ctx context.Context) (channel, error) {
 
 func checkForSerialChannel(ctx context.Context) (*serialChannel, error) {
 	span, _ := trace(ctx, "channel", "checkForSerialChannel")
-	defer span.Finish()
+	defer span.finish()
 
 	// Check serial port path
 	serialPath, serialErr := findVirtualSerialPath(serialChannelName)
 	if serialErr == nil {
-		span.SetTag("channel-type", "serial")
-		span.SetTag("serial-path", serialPath)
+		span.setTag("channel-type", "serial")
+		span.setTag("serial-path", serialPath)
 		agentLog.Debug("Serial channel type detected")
 		return &serialChannel{serialPath: serialPath}, nil
 	}
@@ -107,7 +107,7 @@ func checkForSerialChannel(ctx context.Context) (*serialChannel, error) {
 
 func checkForVsockChannel(ctx context.Context) (*vSockChannel, error) {
 	span, _ := trace(ctx, "channel", "checkForVsockChannel")
-	defer span.Finish()
+	defer span.finish()
 
 	// check vsock path
 	if _, err := os.Stat(vSockDevPath); err != nil {
@@ -116,7 +116,7 @@ func checkForVsockChannel(ctx context.Context) (*vSockChannel, error) {
 
 	vSockSupported, vsockErr := isAFVSockSupportedFunc()
 	if vSockSupported && vsockErr == nil {
-		span.SetTag("channel-type", "vsock")
+		span.setTag("channel-type", "vsock")
 		agentLog.Debug("Vsock channel type detected")
 		return &vSockChannel{}, nil
 	}

--- a/mount.go
+++ b/mount.go
@@ -355,8 +355,8 @@ func mountStorage(storage pb.Storage) error {
 // each storage.
 func addStorages(ctx context.Context, storages []*pb.Storage, s *sandbox) (mounts []string, err error) {
 	span, ctx := trace(ctx, "mount", "addStorages")
-	span.SetTag("sandbox", s.id)
-	defer span.Finish()
+	span.setTag("sandbox", s.id)
+	defer span.finish()
 
 	var mountList []string
 	var storageList []string
@@ -392,7 +392,7 @@ func addStorages(ctx context.Context, storages []*pb.Storage, s *sandbox) (mount
 		// code to each driver.
 		handlerSpan, _ := trace(ctx, "mount", storage.Driver)
 		mountPoint, err := devHandler(ctx, *storage, s)
-		handlerSpan.Finish()
+		handlerSpan.finish()
 
 		if _, ok := s.storages[storage.MountPoint]; ok {
 			storageList = append([]string{storage.MountPoint}, storageList...)

--- a/network.go
+++ b/network.go
@@ -669,7 +669,7 @@ func (s *sandbox) removeNetwork() error {
 // Bring up localhost network interface.
 func (s *sandbox) handleLocalhost() error {
 	span, _ := s.trace("handleLocalhost")
-	defer span.Finish()
+	defer span.finish()
 
 	// If not running as the init daemon, there is nothing to do as the
 	// localhost interface will already exist.

--- a/tracing.go
+++ b/tracing.go
@@ -20,11 +20,53 @@ const (
 	jaegerAgentPort = "6831"
 )
 
+// agentSpan implements opentracing.Span
+type agentSpan struct {
+	span opentracing.Span
+}
+
 // The first trace span
-var rootSpan agentSpan
+var rootSpan *agentSpan
 
 // Implements jaeger-client-go.Logger interface
 type traceLogger struct {
+}
+
+func (a *agentSpan) setTag(key string, value interface{}) *agentSpan {
+	a.span.SetTag(key, value)
+	return a
+}
+
+func (a *agentSpan) finish() {
+	a.span.Finish()
+}
+
+func (a *agentSpan) tracer() agentTracer {
+	return agentTracer{tracer: a.span.Tracer()}
+}
+
+type agentTracer struct {
+	tracer opentracing.Tracer
+}
+
+func (a *agentTracer) startSpan(name string) agentSpan {
+	return agentSpan{span: a.tracer.StartSpan(name)}
+}
+
+func spanFromContext(ctx context.Context) *agentSpan {
+	var a agentSpan
+	a.span = opentracing.SpanFromContext(ctx)
+	return &a
+}
+
+func spanStartFromContext(ctx context.Context, name string) (agentSpan, context.Context) {
+	var a agentSpan
+	a.span, ctx = opentracing.StartSpanFromContext(ctx, name)
+	return a, ctx
+}
+
+func contextWithSpan(ctx context.Context, a agentSpan) context.Context {
+	return opentracing.ContextWithSpan(ctx, a.span)
 }
 
 // tracerCloser contains a copy of the closer returned by createTracer() which
@@ -39,7 +81,7 @@ func (t traceLogger) Infof(msg string, args ...interface{}) {
 	agentLog.Infof(msg, args...)
 }
 
-func createTracer(name string) (opentracing.Tracer, error) {
+func createTracer(name string) (*agentTracer, error) {
 	cfg := &config.Configuration{
 		ServiceName: name,
 
@@ -79,10 +121,10 @@ func createTracer(name string) (opentracing.Tracer, error) {
 	// Seems to be essential to ensure non-root spans are logged
 	opentracing.SetGlobalTracer(tracer)
 
-	return tracer, nil
+	return &agentTracer{tracer: tracer}, nil
 }
 
-func setupTracing(rootSpanName string) (agentSpan, context.Context, error) {
+func setupTracing(rootSpanName string) (*agentSpan, context.Context, error) {
 	ctx := context.Background()
 
 	tracer, err := createTracer(agentName)
@@ -91,9 +133,9 @@ func setupTracing(rootSpanName string) (agentSpan, context.Context, error) {
 	}
 
 	// Create the root span (which is .Finish()'d by stopTracing())
-	span := tracer.StartSpan(rootSpanName)
-	span.SetTag("source", "agent")
-	span.SetTag("root-span", "true")
+	span := tracer.startSpan(rootSpanName)
+	span.setTag("source", "agent")
+	span.setTag("root-span", "true")
 
 	// See comment in trace().
 	if tracing {
@@ -101,9 +143,9 @@ func setupTracing(rootSpanName string) (agentSpan, context.Context, error) {
 	}
 
 	// Associate the root span with the context
-	ctx = opentracing.ContextWithSpan(ctx, span)
+	ctx = contextWithSpan(ctx, span)
 
-	return span, ctx, nil
+	return &span, ctx, nil
 }
 
 // stopTracing() ends all tracing, reporting the spans to the collector.
@@ -117,9 +159,9 @@ func stopTracing(ctx context.Context) {
 		return
 	}
 
-	span := opentracing.SpanFromContext(ctx)
+	span := spanFromContext(ctx)
 	if span != nil {
-		span.Finish()
+		span.finish()
 	}
 
 	// report all possible spans to the collector
@@ -132,10 +174,10 @@ func stopTracing(ctx context.Context) {
 
 // trace creates a new tracing span based on the specified contex, subsystem
 // and name.
-func trace(ctx context.Context, subsystem, name string) (agentSpan, context.Context) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, name)
+func trace(ctx context.Context, subsystem, name string) (*agentSpan, context.Context) {
+	span, ctx := spanStartFromContext(ctx, name)
 
-	span.SetTag("subsystem", subsystem)
+	span.setTag("subsystem", subsystem)
 
 	// This is slightly confusing: when tracing is disabled, trace spans
 	// are still created - but the tracer used is a NOP. Therefore, only
@@ -144,5 +186,5 @@ func trace(ctx context.Context, subsystem, name string) (agentSpan, context.Cont
 		agentLog.Debugf("created span %v", span)
 	}
 
-	return span, ctx
+	return &span, ctx
 }


### PR DESCRIPTION
This wrapper is for opentracing functions, once that we move to another tracer
this will help us to simplify the work by just modifying the name of the function
in a variable instead of renaming all of them in the different files.

Fixes #670

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>