### PR TITLE
docs: Add missing steps at TRACING.md

### DIFF
--- a/TRACING.md
+++ b/TRACING.md
@@ -168,6 +168,7 @@ following:
    - The image **must** include:
      - The `jaeger-client-socat-redirector.service` systemd service
        (see the [Guest to Host communication using VSOCK](#guest-to-host-communication-using-vsock) section).
+       This service should be placed at `/usr/lib/systemd/system/` of the rootfs.
 
      - The distribution-specific package including the `socat(1)` utility
        (normally the package is called `socat`).
@@ -177,8 +178,11 @@ following:
    - The image can include:
      - The `kata-journald-host-redirect.service` service.
        (see the [Guest to Host communication using VSOCK](#guest-to-host-communication-using-vsock) section).
+       This service should be placed at `/usr/lib/systemd/system/` of the rootfs.
+
      - The `kata-redirect-agent-output-to-journal.conf` systemd snippet
        (see the [Guest to Host communication using VSOCK](#guest-to-host-communication-using-vsock) section).
+       This configuration file should be placed at `/etc/systemd/system/kata-agent.service.d/` of the rootfs.
 
 1. Install the custom image.
 


### PR DESCRIPTION
This specifies where the services and the conf should be placed in
order to run the tracing on the agent.

Fixes #674

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>