### PR TITLE
agent: fix pause bin on musl

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -592,7 +592,7 @@ func (s *sandbox) setupSharedPidNs() error {
 
 	cmd := &exec.Cmd{
 		Path: selfBinPath,
-		Args: []string{os.Args[0], pauseBinArg},
+		Env:  []string{fmt.Sprintf("%s=%s", pauseBinKey, pauseBinValue)},
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/pause.go
+++ b/pause.go
@@ -15,10 +15,13 @@ package main
 #include <string.h>
 #include <unistd.h>
 
-#define PAUSE_BIN "pause-bin"
+#define PAUSE_BIN_KEY "pause-bin-key"
+#define PAUSE_BIN_VALUE "pause-bin-value"
 
-void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
-	if (argc != 2 || strcmp(argv[1], PAUSE_BIN)) {
+void __attribute__((constructor)) sandbox_pause() {
+	char *value = getenv(PAUSE_BIN_KEY);
+
+	if (value == NULL || strcmp(value, PAUSE_BIN_VALUE)) {
 		return;
 	}
 
@@ -31,5 +34,6 @@ void __attribute__((constructor)) sandbox_pause(int argc, const char **argv) {
 import "C"
 
 const (
-	pauseBinArg = string(C.PAUSE_BIN)
+	pauseBinKey   = string(C.PAUSE_BIN_KEY)
+	pauseBinValue = string(C.PAUSE_BIN_VALUE)
 )

--- a/pause_test.go
+++ b/pause_test.go
@@ -21,7 +21,7 @@ func TestForkPauseBin(t *testing.T) {
 
 	cmd := &exec.Cmd{
 		Path: selfBinPath,
-		Args: []string{os.Args[0], pauseBinArg},
+		Env:  []string{fmt.Sprintf("%s=%s", pauseBinKey, pauseBinValue)},
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
gcc __attribute__ constructors cannot take arguments and cannot
access main function arguments on musl. Such functionality is glibc
specific and only works on x86 and x86_64. As a result, the pause
binary always quits on musl causing sandbox share pidns to malfunction.

Let's use env to indicate pause instead.

Fixes: #584
Signed-off-by: Peng Tao <bergwolf@hyper.sh>