### PR TITLE
client.go: HybridVSockDialer: Check return size n of unix.Recvfrom

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -9,6 +9,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"strconv"
@@ -418,8 +419,11 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 				return nil, err
 			}
 			eot := make([]byte, 1)
-			if _, _, err = unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil {
+			if n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil || n == 0 {
 				conn.Close()
+				if err == nil {
+					err = io.EOF
+				}
 				return nil, err
 			}
 		}


### PR DESCRIPTION
I found that unix.Recvfrom will not return err to io.EOF if it get
an EOF.  It just set return size n to 0.
That will make function commonDialer return. Grpc dialer will handle
it.

This commit add code to check return size n and set err to io.EOF if
n is 0.

Fixes: #697

Signed-off-by: Hui Zhu <teawater@antfin.com>