### PR TITLE
ci: install docker before configure

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -12,6 +12,10 @@ source "${cidir}/lib.sh"
 pushd "${tests_repo_dir}"
 .ci/run.sh
 testcidir=$(dirname "$0")
+
+echo "Starting docker service before making proto"
+sudo systemctl start docker
+
 "${testcidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r runc -f
 popd
 make proto


### PR DESCRIPTION
run.sh might shutdown docker service and ci would fail when trying
to configure docker runtime.
