### PR TITLE
client.go: HybridVSockDialer: Close dup fd after receive packet

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -419,7 +419,9 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 				return nil, err
 			}
 			eot := make([]byte, 1)
-			if n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil || n == 0 {
+			n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK)
+			file.Close()
+			if err != nil || n == 0 {
 				conn.Close()
 				if err == nil {
 					err = io.EOF


### PR DESCRIPTION
kata runtime jenkins-ci-ubuntu-1804-firecracker always failed when agent
of vendor is updated to new version in
https://github.com/kata-containers/runtime/pull/2285.

This test passed after added code to close dup fd after receive packet
in http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-1804-PR-firecracker/1339/.

Fixes: #703

Signed-off-by: Hui Zhu <teawater@antfin.com>