### PR TITLE
FC: Add new vsock connection handshake

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/yamux"
 	"github.com/mdlayher/vsock"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
@@ -37,6 +39,14 @@ var defaultDialTimeout = 15 * time.Second
 var defaultCloseTimeout = 5 * time.Second
 
 var hybridVSockPort uint32
+
+var agentClientFields = logrus.Fields{
+	"name":   "agent-client",
+	"pid":    os.Getpid(),
+	"source": "agent-client",
+}
+
+var agentClientLog = logrus.WithFields(agentClientFields)
 
 // AgentClient is an agent gRPC client connection wrapper for agentgrpc.AgentServiceClient
 type AgentClient struct {
@@ -413,15 +423,19 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 		// - [host] CONNECT <port><LF>
 		// - [guest/success] OK <assigned_host_port><LF>
 		reader := bufio.NewReader(conn)
-		if response, err := reader.ReadString('\n'); err != nil {
+		response, err := reader.ReadString('\n')
+		if err != nil {
 			conn.Close()
+			agentClientLog.WithField("Error", err).Debug("HybridVsock trivial handshake failed")
 			// for now, we temporarily rely on the backoff strategy from GRPC for more stable CI.
 			return conn, nil
 		} else if !strings.Contains(response, "OK") {
 			conn.Close()
+			agentClientLog.WithField("response", response).Debug("HybridVsock trivial handshake failed with malformd response code")
 			// for now, we temporarily rely on the backoff strategy from GRPC for more stable CI.
 			return conn, nil
 		}
+		agentClientLog.WithField("response", response).Debug("HybridVsock trivial handshake")
 
 		return conn, nil
 	}


### PR DESCRIPTION
**Which feature do you think can be improved?**
New Firecracker `v0.20.0` has changed the host-initiated vsock connection protocol to include a trivial handshake.

The new protocol looks like this:
```
    - [host] CONNECT <port><LF>
    - [guest/success] OK <assigned_host_port><LF>
```
See PR [firecracker-microvm/firecracker#1472](https://github.com/firecracker-microvm/firecracker/pull/1472) for detailed info.
