### PR TITLE
Revert: client.go: HybridVSockDialer: Change Read EOT to recv peek

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -13,14 +13,12 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/hashicorp/yamux"
 	"github.com/mdlayher/vsock"
 	opentracing "github.com/opentracing/opentracing-go"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
@@ -409,19 +407,12 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 			return nil, err
 		}
 
-		// Receive the packet from the connection without removing it from
-		// the receive queue (MSG_PEEK), ensuring the connection is usable.
-		if uc, ok := conn.(*net.UnixConn); ok {
-			file, err := uc.File()
-			if err != nil {
-				conn.Close()
-				return nil, err
-			}
-			eot := make([]byte, 1)
-			if _, _, err = unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil {
-				conn.Close()
-				return nil, err
-			}
+		// Read EOT (End of transmission) byte
+		eot := make([]byte, 32)
+		if _, err = conn.Read(eot); err != nil {
+			// Just close the connection, gRPC will dial again
+			// without errors
+			conn.Close()
 		}
 
 		return conn, nil

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -9,7 +9,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
 	"strconv"
@@ -419,11 +418,8 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 				return nil, err
 			}
 			eot := make([]byte, 1)
-			if n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil || n == 0 {
+			if _, _, err = unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil {
 				conn.Close()
-				if err == nil {
-					err = io.EOF
-				}
 				return nil, err
 			}
 		}

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -419,9 +419,7 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 				return nil, err
 			}
 			eot := make([]byte, 1)
-			n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK)
-			file.Close()
-			if err != nil || n == 0 {
+			if n, _, err := unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil || n == 0 {
 				conn.Close()
 				if err == nil {
 					err = io.EOF


### PR DESCRIPTION
Revert changes as bring some instability to CI. After find the root cause it will be merged again.

Fixes: #716

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>