### PR TITLE
ipv6: Add support for ipv6

### DIFF
--- a/network.go
+++ b/network.go
@@ -114,7 +114,7 @@ func updateLink(netHandle *netlink.Handle, link netlink.Link, iface *types.Inter
 	}
 
 	// As a first step, clear out any existing addresses associated with the link:
-	linkIPs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	linkIPs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		return grpcStatus.Errorf(codes.Internal, "Could not check initial addresses for the link: %v", err)
 	}
@@ -297,7 +297,7 @@ func getInterface(netHandle *netlink.Handle, link netlink.Link) (*types.Interfac
 	ifc.Mtu = uint64(linkAttrs.MTU)
 	ifc.HwAddr = linkAttrs.HardwareAddr.String()
 
-	addrs, err := netHandle.AddrList(link, netlink.FAMILY_V4)
+	addrs, err := netHandle.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		agentLog.WithError(err).Error("getInterface() failed")
 		return nil, err
@@ -307,6 +307,11 @@ func getInterface(netHandle *netlink.Handle, link netlink.Link) (*types.Interfac
 		m := types.IPAddress{
 			Address: addr.IP.String(),
 			Mask:    fmt.Sprintf("%d", netMask),
+		}
+		if addr.IP.To4() != nil {
+			m.Family = types.IPFamily_v4
+		} else {
+			m.Family = types.IPFamily_v6
 		}
 		ifc.IPAddresses = append(ifc.IPAddresses, &m)
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -254,7 +254,14 @@ func TestListInterfaces(t *testing.T) {
 		Address: "192.168.0.101",
 		Mask:    "24",
 	}
+	ipv4addr := types.IPAddress{
+		Family:  1,
+		Address: "2001:db8:1::242:ac11:5",
+		Mask:    "64",
+	}
+
 	ifc.IPAddresses = append(ifc.IPAddresses, &ip)
+	ifc.IPAddresses = append(ifc.IPAddresses, &ipv4addr)
 	netHandle, _ := netlink.NewHandle()
 	defer netHandle.Delete()
 	// create a dummy link that we can test update on
@@ -275,8 +282,25 @@ func TestListInterfaces(t *testing.T) {
 	//
 	results, err := s.listInterfaces(nil)
 	assert.Nil(err, "Expected to list all interfaces")
-	assert.True(reflect.DeepEqual(results.Interfaces[1], &ifc),
-		"Interface listed didn't match: got %+v, expecting %+v", results.Interfaces[1], &ifc)
+
+	resifc := results.Interfaces[1]
+	assert.Equal(resifc.Name, ifc.Name)
+	assert.Equal(resifc.Mtu, ifc.Mtu)
+	assert.Equal(resifc.HwAddr, ifc.HwAddr)
+
+	for i, ip := range ifc.IPAddresses {
+		assert.True(reflect.DeepEqual(resifc.IPAddresses[i], ip),
+			"Interface address didn't match: got %+v, expecting %+v", resifc.IPAddresses[i], ip)
+	}
+
+	// An ipv6 link local address is created by default, using the mac address.
+	// Check if the additional address is indeed an ipv6 link local address.
+	if len(resifc.IPAddresses) > len(ifc.IPAddresses) {
+		ipAddr := resifc.IPAddresses[2]
+		assert.Equal(ipAddr.Family, types.IPFamily_v6)
+		ip := net.ParseIP(ipAddr.Address)
+		assert.True(ip.IsLinkLocalUnicast())
+	}
 }
 
 func TestListRoutes(t *testing.T) {
@@ -351,6 +375,73 @@ func TestListRoutes(t *testing.T) {
 		"Route listed didn't match: got %+v, expecting %+v", results.Routes[0], inputRoutesSimple[0])
 	assert.True(reflect.DeepEqual(results.Routes[1], inputRoutesSimple[1]),
 		"Route listed didn't match: got %+v, expecting %+v", results.Routes[1], inputRoutesSimple[1])
+}
+
+func TestListRoutesWithIPV6(t *testing.T) {
+	tearDown := setupNetworkTest(t)
+	defer tearDown()
+
+	assert := assert.New(t)
+
+	s := sandbox{}
+
+	// create a dummy link which we'll play with
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x48}
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			MTU:          1500,
+			TxQLen:       -1,
+			Name:         "ifc-name",
+			HardwareAddr: macAddr,
+		},
+	}
+	netHandle, _ := netlink.NewHandle()
+	defer netHandle.Delete()
+
+	netHandle.LinkAdd(link)
+	if err := netHandle.LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+	netlinkAddr, _ := netlink.ParseAddr("192.168.0.2/16")
+	netHandle.AddrAdd(link, netlinkAddr)
+
+	netlinkAddrV6, _ := netlink.ParseAddr("2001:db8:1::242:ac11:2/64")
+	netHandle.AddrAdd(link, netlinkAddrV6)
+
+	//Test a simple route setup:
+	inputRoutesSimple := []*types.Route{
+		{Dest: "", Gateway: "192.168.0.1", Source: "", Scope: 0, Device: "ifc-name"},
+		{Dest: "", Gateway: "2001:db8:1::1", Source: "", Scope: 0, Device: "ifc-name"},
+	}
+
+	expectedRoutes := []*types.Route{
+		{Dest: "", Gateway: "192.168.0.1", Source: "", Scope: 0, Device: "ifc-name"},
+		// This route is auto-added by kernel, and we no longer delete kernel proto routes
+		{Dest: "192.168.0.0/16", Gateway: "", Source: "192.168.0.2", Scope: 253, Device: "ifc-name"},
+		{Dest: "2001:db8:1::/64", Gateway: "", Source: "", Scope: 0, Device: "ifc-name"},
+		{Dest: "fe80::/64", Gateway: "", Source: "", Scope: 0, Device: "ifc-name"},
+		{Dest: "", Gateway: "2001:db8:1::1", Source: "", Scope: 0, Device: "ifc-name"},
+	}
+
+	testRoutes := &pb.Routes{
+		Routes: inputRoutesSimple,
+	}
+
+	_, err := s.updateRoutes(netHandle, testRoutes)
+	assert.Nil(err)
+	results, err := s.listRoutes(nil)
+	assert.Nil(err, "Expected to list all routes")
+
+	assert.True(reflect.DeepEqual(results.Routes[0], expectedRoutes[0]),
+		"Route listed didn't match: got %+v, expecting %+v", results.Routes[0], expectedRoutes[0])
+	assert.True(reflect.DeepEqual(results.Routes[1], expectedRoutes[1]),
+		"Route listed didn't match: got %+v, expecting %+v", results.Routes[1], expectedRoutes[1])
+	assert.True(reflect.DeepEqual(results.Routes[2], expectedRoutes[2]),
+		"Route listed didn't match: got %+v, expecting %+v", results.Routes[2], expectedRoutes[2])
+	assert.True(reflect.DeepEqual(results.Routes[3], expectedRoutes[3]),
+		"Route listed didn't match: got %+v, expecting %+v", results.Routes[3], expectedRoutes[3])
+	assert.True(reflect.DeepEqual(results.Routes[4], expectedRoutes[4]),
+		"Route listed didn't match: got %+v, expecting %+v", results.Routes[4], expectedRoutes[4])
 }
 
 func TestListRoutesWithTwoInterfacesSameSubnet(t *testing.T) {

--- a/network_test.go
+++ b/network_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/kata-containers/agent/pkg/types"
@@ -300,6 +301,16 @@ func TestListInterfaces(t *testing.T) {
 		assert.Equal(ipAddr.Family, types.IPFamily_v6)
 		ip := net.ParseIP(ipAddr.Address)
 		assert.True(ip.IsLinkLocalUnicast())
+	}
+
+	// Check IFA_F_NODAD flag is set on ipv6 address
+	l, err := netlink.LinkByName(ifc.Name)
+	assert.Nil(err)
+	addrList, err := netlink.AddrList(l, netlink.FAMILY_V6)
+	assert.Nil(err)
+
+	if addrList[0].Flags&syscall.IFA_F_NODAD == 0 {
+		t.Fatalf("Unexpected interface flags for addr %+v: 0x%x. Expected to contain 0x%x", addrList[0], addrList[0].Flags, syscall.IFA_F_NODAD)
 	}
 }
 


### PR DESCRIPTION
Do not ignore ipv6 addresses and routes. These are not processes along
with ipv4 routes.
Add tests to verify ipv6 addresses and routes are processed
with `updateRoutes`.

Depends-on: github.com/kata-containers/runtime#2420
Fixes #721

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>