### PR TITLE
build: Add --nogpgcheck to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG arch
 # ENV GIT_SSL_NO_VERIFY true
 
 # install building tools
-RUN yum makecache && yum install -y \
+RUN yum makecache && yum install -y --nogpgcheck \
 	git automake libtool glibc-headers gcc-c++ make
 
 # install GO development environment


### PR DESCRIPTION
While trying to build the CentOS 7 image on Fedora 31, we have seen
failures while trying to install the dependencies packages. This PR fixes
that issue.

Fixes #725

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>