### PR TITLE
DNM: Update CentOS version for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # It includes some useful tools for development of agent
 # which can ensure everyone using similar development toolkit
 
-FROM centos:7
+FROM centos:8
 
 ARG http_proxy
 ARG https_proxy


### PR DESCRIPTION
This PR updates the CentOS version that we are using for the Dockerfile
which is being used to generate and build the images.

Fixes #727

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>