### PR TITLE
protocols: Fix Cloud-Hypervisor CI regarding hvsock

### DIFF
--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -9,6 +9,7 @@ package client
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -427,13 +428,11 @@ func HybridVSockDialer(sock string, timeout time.Duration) (net.Conn, error) {
 		if err != nil {
 			conn.Close()
 			agentClientLog.WithField("Error", err).Debug("HybridVsock trivial handshake failed")
-			// for now, we temporarily rely on the backoff strategy from GRPC for more stable CI.
-			return conn, nil
+			return nil, err
 		} else if !strings.Contains(response, "OK") {
 			conn.Close()
 			agentClientLog.WithField("response", response).Debug("HybridVsock trivial handshake failed with malformd response code")
-			// for now, we temporarily rely on the backoff strategy from GRPC for more stable CI.
-			return conn, nil
+			return nil, errors.New("hvsock response does not contain \"OK\"")
 		}
 		agentClientLog.WithField("response", response).Debug("HybridVsock trivial handshake")
 

--- a/protocols/client/client.go
+++ b/protocols/client/client.go
@@ -35,7 +35,7 @@ const (
 	HybridVSockScheme = "hvsock"
 )
 
-var defaultDialTimeout = 15 * time.Second
+var defaultDialTimeout = 60 * time.Second
 var defaultCloseTimeout = 5 * time.Second
 
 var hybridVSockPort uint32


### PR DESCRIPTION
This PR fixes Cloud-Hypervisor CI by increasing the connection retry timeout from 15s to 60s as it can take some time for the agent to listen onto the vosck socket when running in nested virtualization environment.

Because of this fix, the PR also re-enable the proper error handling, leading to a faster connection retry, instead of relying on the GRPC backoff strategy.

Fixes #732 