### PR TITLE
agent: configure nvidia GPU access for the container

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -668,6 +668,16 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		return emptyResp, err
 	}
 
+	for _, e := range ociSpec.Process.Env {
+		if strings.HasPrefix(e, "NVIDIA_VISIBLE_DEVICES=") {
+			err := setupNvidiaDriver(ociSpec.Root.Path)
+			if err != nil {
+				return emptyResp, err
+			}
+			break
+		}
+	}
+
 	if a.sandbox.guestHooksPresent {
 		// Add any custom OCI hooks to the spec
 		a.sandbox.addGuestHooks(ociSpec)

--- a/nvidia.go
+++ b/nvidia.go
@@ -1,0 +1,116 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const ldconfPath = "/etc/ld.so.conf"
+
+func setupNvidiaDriver(containerRootfs string) (err error) {
+	bins, libs, err := getNvidiaFiles()
+	if err != nil {
+		return
+	}
+
+	// mount driver binaries
+	for _, binFile := range bins {
+		if err = mount(binFile, filepath.Join(containerRootfs, binFile), "bind", unix.MS_BIND|unix.MS_REC|unix.MS_RDONLY, "rbind"); err != nil {
+			return
+		}
+	}
+
+	// mount driver libraries
+	libDirsMap := make(map[string]interface{})
+	for _, libFile := range libs {
+		if err = mount(libFile, filepath.Join(containerRootfs, libFile), "bind", unix.MS_BIND|unix.MS_REC|unix.MS_RDONLY, "rbind"); err != nil {
+			return
+		}
+		libDir := filepath.Dir(libFile)
+		libDirsMap[libDir] = nil
+	}
+
+	// configure dynamic linker run-time bindings
+	ldArgs := []string{"-r", containerRootfs}
+	for dir := range libDirsMap {
+		ldArgs = append(ldArgs, filepath.Join(containerRootfs, dir))
+	}
+	ldCmd := exec.Command("ldconfig", ldArgs...)
+	err = ldCmd.Run()
+	if err != nil {
+		return
+	}
+	// write libdirs to ld.so.conf
+	confFile, err := os.OpenFile(filepath.Join(containerRootfs, ldconfPath), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return
+	}
+	defer confFile.Close()
+	for dir := range libDirsMap {
+		if _, err = fmt.Fprintln(confFile, dir); err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func getNvidiaFiles() (bins []string, libs []string, err error) {
+	// "--load-kmods": Load kernel modules
+	// "info": Report information about the driver and devices
+	infoCmd := exec.Command("nvidia-container-cli", "--load-kmods", "info")
+	if err = infoCmd.Run(); err != nil {
+		return
+	}
+
+	// List driver binaries
+	lbinCmd := exec.Command("nvidia-container-cli", "list", "--binaries")
+	if bins, err = runGetOutputLines(lbinCmd); err != nil {
+		return
+	}
+
+	//  List driver libraries
+	llibCmd := exec.Command("nvidia-container-cli", "list", "--libraries")
+	if libs, err = runGetOutputLines(llibCmd); err != nil {
+		return
+	}
+
+	return
+}
+
+func runGetOutputLines(cmd *exec.Cmd) (outputLines []string, err error) {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	if err = cmd.Start(); err != nil {
+		return
+	}
+
+	outputBuf := bufio.NewReader(stdout)
+	var line []byte
+	for {
+		line, _, err = outputBuf.ReadLine()
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return
+		}
+		outputLines = append(outputLines, string(line))
+	}
+
+	if err = cmd.Wait(); err != nil {
+		return
+	}
+
+	return
+}

--- a/nvidia_test.go
+++ b/nvidia_test.go
@@ -1,0 +1,42 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestRunGetOutputLines(t *testing.T) {
+	type args struct {
+		cmd *exec.Cmd
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantOutputLines []string
+		wantErr         bool
+	}{
+		{
+			name:            "successfulCase",
+			args:            args{cmd: exec.Command("echo", "-e", "abc\ndef")},
+			wantOutputLines: []string{"abc", "def"},
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOutputLines, err := runGetOutputLines(tt.args.cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runGetOutputLines() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotOutputLines, tt.wantOutputLines) {
+				t.Errorf("runGetOutputLines() gotOutputLines = %v, want %v", gotOutputLines, tt.wantOutputLines)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With nvidia-container-cli and nvidia driver installed into the rootfs of kata vm, if environment variable NVIDIA_VISIBLE_DEVICES is set in the OCI spec, the agent will configure GPU access for the container by leveraging nvidia-container-cli from project libnvidia-container.

Fixes: #735

Signed-off-by: Aohan Yang <aohan@nuaa.edu.cn>