### PR TITLE
agent: don't receive signals from stdin

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1445,6 +1445,11 @@ func init() {
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}
+
+	// agent won't receive anything from the stdin.
+	// Close stdin to avoid the agent receives signals
+	// (ctrl + c/d) from the stdin.
+	os.Stdin.Close()
 }
 
 func realMain() error {


### PR DESCRIPTION
close stdin to avoid agent be killed through the stdin

fixes #746

Signed-off-by: Julio Montes <julio.montes@intel.com>