### PR TITLE
agent: support pmem/nvdimm hotplug

### DIFF
--- a/device.go
+++ b/device.go
@@ -46,6 +46,7 @@ var (
 	pciBusPathFormat    = "%s/%s/pci_bus/"
 	systemDevPath       = "/dev"
 	getSCSIDevPath      = getSCSIDevPathImpl
+	getPmemDevPath      = getPmemDevPathImpl
 	getPCIDeviceName    = getPCIDeviceNameImpl
 	getDevicePCIAddress = getDevicePCIAddressImpl
 	scanSCSIBus         = scanSCSIBusImpl
@@ -355,6 +356,13 @@ func getSCSIDevPathImpl(s *sandbox, scsiAddr string) (string, error) {
 	}
 
 	devPath := filepath.Join(scsiHostChannel+scsiAddr, scsiBlockSuffix)
+
+	return getDeviceName(s, devPath)
+}
+
+func getPmemDevPathImpl(s *sandbox, devPmemPath string) (string, error) {
+	// for example: /block/pmem1
+	devPath := filepath.Join("/", scsiBlockSuffix, filepath.Base(devPmemPath))
 
 	return getDeviceName(s, devPath)
 }

--- a/device_amd64.go
+++ b/device_amd64.go
@@ -9,4 +9,15 @@ package main
 
 const (
 	rootBusPath = "/devices/pci0000:00"
+
+	// From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
+	// The Linux kernel's core ACPI subsystem creates struct acpi_device
+	// objects for ACPI namespace objects representing devices, power resources
+	// processors, thermal zones. Those objects are exported to user space via
+	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
+	acpiDevPath = "/devices/LNXSYSTM"
+
+	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
+	// in a subdirectory whose prefix is pfn (page frame number).
+	pfnDevPrefix = "/pfn"
 )

--- a/device_arm64.go
+++ b/device_arm64.go
@@ -6,4 +6,17 @@
 
 package main
 
-const rootBusPath = "/devices/platform/4010000000.pcie/pci0000:00"
+const (
+	rootBusPath = "/devices/platform/4010000000.pcie/pci0000:00"
+
+	// From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
+	// The Linux kernel's core ACPI subsystem creates struct acpi_device
+	// objects for ACPI namespace objects representing devices, power resources
+	// processors, thermal zones. Those objects are exported to user space via
+	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
+	acpiDevPath = "/devices/LNXSYSTM"
+
+	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
+	// in a subdirectory whose prefix is pfn (page frame number).
+	pfnDevPrefix = "/pfn"
+)

--- a/device_ppc64le.go
+++ b/device_ppc64le.go
@@ -9,4 +9,15 @@ package main
 
 const (
 	rootBusPath = "/devices/pci0000:00"
+
+	// From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
+	// The Linux kernel's core ACPI subsystem creates struct acpi_device
+	// objects for ACPI namespace objects representing devices, power resources
+	// processors, thermal zones. Those objects are exported to user space via
+	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
+	acpiDevPath = "/devices/LNXSYSTM"
+
+	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
+	// in a subdirectory whose prefix is pfn (page frame number).
+	pfnDevPrefix = "/pfn"
 )

--- a/device_s390x.go
+++ b/device_s390x.go
@@ -9,4 +9,15 @@ package main
 
 const (
 	rootBusPath = "/devices/css0"
+
+	// From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
+	// The Linux kernel's core ACPI subsystem creates struct acpi_device
+	// objects for ACPI namespace objects representing devices, power resources
+	// processors, thermal zones. Those objects are exported to user space via
+	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
+	acpiDevPath = "/devices/LNXSYSTM"
+
+	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
+	// in a subdirectory whose prefix is pfn (page frame number).
+	pfnDevPrefix = "/pfn"
 )


### PR DESCRIPTION
Agent has to wait for pmem/nvdimm devices to appear in the guest.
The agent can use udev and the ACPI device path to identify when a pmem/nvdimm
device has been hotplugged in the guest.
For example when `/dev/pmem1` is hotplugged, the ACPI dev path may look like:

```
/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region1/pfn1.1/block/pmem1
```

The udev routine catches the above path and return the full path to the device:
`/dev/pmem1`

fixes #753

Signed-off-by: Julio Montes <julio.montes@intel.com>


cc @amshinde @lifupan @jodh-intel 