### PR TITLE
agent: fix epoll fd left in the kata-agent when exec process

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -254,6 +254,7 @@ func (p *process) closePostExitFDs() {
 
 	if p.epoller != nil {
 		p.epoller.sockR.Close()
+		unix.Close(p.epoller.fd)
 	}
 }
 


### PR DESCRIPTION
reason: If someone want to exec a process in the container, kata-agent will
create a epollfd to monitor the pts fd event. However epollfd is not closed
when exec process exit, which cause fd is left in the kata-agent process.

fixes: #762

Signed-off-by: jiangpengfei <jiangpengfei9@huawei.com>