### PR TITLE
agent: signal from keyboard must not be fatal

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1493,11 +1493,6 @@ func init() {
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}
-
-	// agent won't receive anything from the stdin.
-	// Close stdin to avoid the agent receives signals
-	// (ctrl + c/d) from the stdin.
-	os.Stdin.Close()
 }
 
 func realMain() error {

--- a/signals.go
+++ b/signals.go
@@ -20,10 +20,14 @@ import (
 //
 // The value is true if receiving the signal should be fatal.
 var handledSignalsMap = map[syscall.Signal]bool{
-	syscall.SIGABRT:   true,
-	syscall.SIGBUS:    true,
-	syscall.SIGILL:    true,
-	syscall.SIGQUIT:   true,
+	syscall.SIGABRT: true,
+	syscall.SIGBUS:  true,
+	syscall.SIGILL:  true,
+	// Signals from the keyboard (INT and QUIT) *must not* be fatal
+	// otherwise the agent could be killed from the host through
+	// the console.sock.
+	syscall.SIGINT:    false,
+	syscall.SIGQUIT:   false,
 	syscall.SIGSEGV:   true,
 	syscall.SIGSTKFLT: true,
 	syscall.SIGSYS:    true,


### PR DESCRIPTION
Don't close stdin, since it's used as the controlling terminal for the agent
when it's the init process, instead the signals from the keyboard must not be
fatal.

fixes #765
fixes github.com/kata-containers/tests#2405

Signed-off-by: Julio Montes <julio.montes@intel.com>