### PR TITLE
protocols: fix client unit tests for go 1.13

### DIFF
--- a/protocols/client/client_test.go
+++ b/protocols/client/client_test.go
@@ -131,7 +131,7 @@ func TestNewAgentClient(t *testing.T) {
 	cliFunc(mockBadSchemeAddr, false, "Invalid scheme:")
 	cliFunc(mockBadVsockScheme, false, "Invalid vsock scheme:")
 	cliFunc(mockVsockBadCid, false, "Invalid vsock cid")
-	cliFunc(mockVsockBadPort, false, "Invalid vsock port")
+	cliFunc(mockVsockBadPort, false, "invalid port")
 	cliFunc(mockFakeVsockAddr, false, "context deadline exceeded")
 
 	// wait mock server to stop
@@ -153,7 +153,7 @@ func TestNewAgentClientWithYamux(t *testing.T) {
 	cliFunc(mockBadSchemeAddr, false, "Invalid scheme:")
 	cliFunc(mockBadVsockScheme, false, "Invalid vsock scheme:")
 	cliFunc(mockVsockBadCid, false, "Invalid vsock cid")
-	cliFunc(mockVsockBadPort, false, "Invalid vsock port")
+	cliFunc(mockVsockBadPort, false, "invalid port")
 	cliFunc(mockFakeVsockAddr, false, "context deadline exceeded")
 
 	// wait mock server to stop


### PR DESCRIPTION
The way to parse URLs in Go 1.13 has changed, now the `url.Parse` validates
that the port is only decimals, so the content of the error message when a
invalid port is used will change from "Invalid vsock port" to "invalid port",
hence the expected error message in the unit tests must change.

For more information about the change in Golang 1.13 see:
https://github.com/golang/go/commit/61bb56ad63992a3199acc55b2537c8355ef887b6

fixes #772

Signed-off-by: Julio Montes <julio.montes@intel.com>