### PR TITLE
vsock: initiate a quick handshake to avoid VSOCK_DEFAULT_CONNECT_TIMEOUT(WIP)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -176,6 +176,9 @@ var debugConsole = false
 // Specify a vsock port where logs are written.
 var logsVSockPort = uint32(0)
 
+// Specify a vsock host port to do a quick handshake.
+var vsockHostPort = uint32(0)
+
 // Specify a vsock port where debug console is attached.
 var debugConsoleVSockPort = uint32(0)
 

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ const (
 	devModeFlag                = optionPrefix + "devmode"
 	traceModeFlag              = optionPrefix + "trace"
 	useVsockFlag               = optionPrefix + "use_vsock"
+	vsockHostPortFlag          = optionPrefix + "vsock_host_port"
 	debugConsoleFlag           = optionPrefix + "debug_console"
 	debugConsoleVPortFlag      = optionPrefix + "debug_console_vport"
 	hotplugTimeoutFlag         = optionPrefix + "hotplug_timeout"
@@ -149,6 +150,12 @@ func parseCmdlineOption(option string) error {
 			agentLog.Debug("Param passed to NOT use vsock channel")
 			commCh = serialCh
 		}
+	case vsockHostPortFlag:
+		port, err := strconv.ParseUint(split[valuePosition], 10, 32)
+		if err != nil {
+			return err
+		}
+		vsockHostPort = uint32(port)
 	case unifiedCgroupHierarchyFlag:
 		flag, err := strconv.ParseBool(split[valuePosition])
 		if err != nil {


### PR DESCRIPTION
We will suffer default two seconds timeout, when kata-runtime initiates a connection to agent server, and right now vsock transport in guest part isn't ready.
Here, taking advices from Stefan Hajnoczi, we will do a quick handshake to ensure host initiating connection until vsock device is completely ready.
The quick handshake follows below steps:
1. kata-runtime listens on a vsock port
2. `agent.vsock_host_port=PORT` is added to the kernel command-line options
3. kata-agent parses the port number and connects to the host
This commit covers the third part in kata-agent.

Fixes: #775

Signed-off-by: Penny Zheng <penny.zheng@arm.com>