### PR TITLE
channel: fix the issue of epoll_wait interrupted by signal

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -194,6 +195,10 @@ func (c *serialChannel) wait() error {
 	for {
 		nev, err := unix.EpollWait(epfd, events[:], -1)
 		if err != nil {
+			if err == syscall.EINTR {
+				continue
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
The epoll_wait syscall would be interrupted by signal,
thus it's better to ignore this interrupted error.

Fixes: #779

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>