### PR TITLE
device: Do not rescan PCI bus

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -30,7 +30,6 @@ const (
 	testExecID      = "testExecID"
 	testContainerID = "testContainerID"
 	testFileMode    = os.FileMode(0640)
-	testDirMode     = os.FileMode(0750)
 )
 
 func createFileWithPerms(file, contents string, perms os.FileMode) error {

--- a/device.go
+++ b/device.go
@@ -37,13 +37,8 @@ const (
 	vmRootfs            = "/"
 )
 
-const (
-	pciBusMode = 0220
-)
-
 var (
 	sysBusPrefix        = sysfsDir + "/bus/pci/devices"
-	pciBusRescanFile    = sysfsDir + "/bus/pci/rescan"
 	pciBusPathFormat    = "%s/%s/pci_bus/"
 	systemDevPath       = "/dev"
 	getSCSIDevPath      = getSCSIDevPathImpl
@@ -79,10 +74,6 @@ var deviceHandlerList = map[string]deviceHandler{
 	driverBlkCCWType:  virtioBlkCCWDeviceHandler,
 	driverSCSIType:    virtioSCSIDeviceHandler,
 	driverNvdimmType:  nvdimmDeviceHandler,
-}
-
-func rescanPciBus() error {
-	return ioutil.WriteFile(pciBusRescanFile, []byte{'1'}, pciBusMode)
 }
 
 // getDevicePCIAddress fetches the complete PCI address in sysfs, based on the PCI
@@ -176,14 +167,6 @@ func getDeviceName(s *sandbox, devID string) (string, error) {
 func getPCIDeviceNameImpl(s *sandbox, pciID string) (string, error) {
 	pciAddr, err := getDevicePCIAddress(pciID)
 	if err != nil {
-		return "", err
-	}
-
-	fieldLogger := agentLog.WithField("pciAddr", pciAddr)
-
-	// Rescan pci bus if we need to wait for a new pci device
-	if err = rescanPciBus(); err != nil {
-		fieldLogger.WithError(err).Error("Failed to scan pci bus")
 		return "", err
 	}
 

--- a/device_test.go
+++ b/device_test.go
@@ -504,45 +504,6 @@ func TestUpdateSpecDeviceList(t *testing.T) {
 	assert.NoError(err)
 }
 
-func TestRescanPciBus(t *testing.T) {
-	skipUnlessRoot(t)
-
-	assert := assert.New(t)
-
-	err := rescanPciBus()
-	assert.Nil(err)
-
-}
-
-func TestRescanPciBusSubverted(t *testing.T) {
-	assert := assert.New(t)
-
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
-
-	rescanDir := filepath.Join(dir, "rescan-dir")
-
-	err = os.MkdirAll(rescanDir, testDirMode)
-	assert.NoError(err)
-
-	rescan := filepath.Join(rescanDir, "rescan")
-
-	savedFile := pciBusRescanFile
-	defer func() {
-		pciBusRescanFile = savedFile
-	}()
-
-	pciBusRescanFile = rescan
-
-	err = rescanPciBus()
-	assert.NoError(err)
-
-	os.RemoveAll(rescanDir)
-	err = rescanPciBus()
-	assert.Error(err)
-}
-
 func TestVirtioMmioBlkDeviceHandler(t *testing.T) {
 	assert := assert.New(t)
 
@@ -632,13 +593,6 @@ func TestGetPCIDeviceName(t *testing.T) {
 	sb := sandbox{
 		deviceWatchers: make(map[string](chan string)),
 	}
-
-	_, err = getPCIDeviceNameImpl(&sb, "")
-	assert.Error(err)
-
-	rescanDir := filepath.Dir(pciBusRescanFile)
-	err = os.MkdirAll(rescanDir, testDirMode)
-	assert.NoError(err)
 
 	_, err = getPCIDeviceNameImpl(&sb, "")
 	assert.Error(err)

--- a/grpc.go
+++ b/grpc.go
@@ -618,12 +618,6 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		return emptyResp, err
 	}
 
-	// re-scan PCI bus
-	// looking for hidden devices
-	if err = rescanPciBus(); err != nil {
-		agentLog.WithError(err).Warn("Could not rescan PCI bus")
-	}
-
 	// Some devices need some extra processing (the ones invoked with
 	// --device for instance), and that's what this call is doing. It
 	// updates the devices listed in the OCI spec, so that they actually


### PR DESCRIPTION
PCI bus rescan code was added long time ago in Clear Containers due to lack of
ACPI support in QEMU 2.9 + q35 [1]. Now this code is messing up PCIe hotplug
in Kata Containers. A workaround to this issue is the "lazy attach"
mechanism [2] that hotplugs LBS (Large BAR space) devices after re-scanning the
PCI bus, unfourtunately some non-LBS devices are being affected too, for
instance SR-IOV devices. It would not make sense to lazy-attach non-LBS
devices because kata will end up lazy-attaching all the devices, having said
that, the PCI bus rescan code and the "lazy attach" mechanism should be removed

Depends-on: github.com/kata-containers/runtime#2670
fixes #781
fixes kata-containers/runtime#2664

[1] https://github.com/clearcontainers/agent/pull/139
[2] https://github.com/kata-containers/runtime/pull/2461

Signed-off-by: Julio Montes <julio.montes@intel.com>