### PR TITLE
device: Do not allow container access to the nvdimm rootfs

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -654,6 +654,9 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		}
 	}()
 
+	// Add the nvdimm root partition to the device cgroup to prevent access
+	updateDeviceCgroupForGuestRootfs(req.OCI)
+
 	// Convert the spec to an actual OCI specification structure.
 	ociSpec, err := pb.GRPCtoOCI(req.OCI)
 	if err != nil {


### PR DESCRIPTION
With this change, a container is not longer given access to
the underlying nvdimm root partition.
This is done by explicitly adding the nvdimm root partition
to the device cgroup of the container.

Fixes #791

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>