### PR TITLE
backport: device: Do not allow container access to the nvdimm rootfs

### DIFF
--- a/device.go
+++ b/device.go
@@ -34,6 +34,7 @@ const (
 	driverNvdimmType    = "nvdimm"
 	driverEphemeralType = "ephemeral"
 	driverLocalType     = "local"
+	vmRootfs            = "/"
 )
 
 const (
@@ -463,4 +464,29 @@ func addDevice(ctx context.Context, device *pb.Device, spec *pb.Spec, s *sandbox
 	}
 
 	return devHandler(ctx, *device, spec, s)
+}
+
+// updateDeviceCgroupForGuestRootfs updates the device cgroup for container
+// to not allow access to the nvdim root partition. This prevents the container
+// from being able to access the VM rootfs.
+func updateDeviceCgroupForGuestRootfs(spec *pb.Spec) {
+	var devStat unix.Stat_t
+
+	err := unix.Stat(vmRootfs, &devStat)
+	if err != nil {
+		return
+	}
+
+	devMajor := int64(unix.Major(devStat.Dev))
+	devMinor := int64(unix.Minor(devStat.Dev))
+
+	nvdimmCg := pb.LinuxDeviceCgroup{
+		Allow:  false,
+		Major:  devMajor,
+		Minor:  devMinor,
+		Type:   "b",
+		Access: "rwm",
+	}
+
+	spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, nvdimmCg)
 }

--- a/grpc.go
+++ b/grpc.go
@@ -653,6 +653,9 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		}
 	}()
 
+	// Add the nvdimm root partition to the device cgroup to prevent access
+	updateDeviceCgroupForGuestRootfs(req.OCI)
+
 	// Convert the spec to an actual OCI specification structure.
 	ociSpec, err := pb.GRPCtoOCI(req.OCI)
 	if err != nil {


### PR DESCRIPTION
With this change, a container is not longer given access to
the underlying nvdimm root partition.
This is done by explicitly adding the nvdimm root partition
to the device cgroup of the container.

Fixes #791

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit a88af321f7c591404b0316320c46591fa8250992)