### PR TITLE
device: Ease device access for rootfs device to allow node creation

### DIFF
--- a/device.go
+++ b/device.go
@@ -496,7 +496,7 @@ func updateDeviceCgroupForGuestRootfs(spec *pb.Spec) {
 		Major:  devMajor,
 		Minor:  devMinor,
 		Type:   "b",
-		Access: "rwm",
+		Access: "rw",
 	}
 
 	spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, nvdimmCg)


### PR DESCRIPTION
For docker in docker scenario, the nested container created
has entry "b *:* m" in the list of devices it is allowed to access
under /sys/fs/cgroup/devices/docker/{ctrid}/devices.list.

This entry was causing issues while starting a nested container
as we were denying "m" access to the rootfs block devices.
With this change we add back "m" access, the container would be
allowed to create a device node for the rootfs device but will
 not have read-write access to the created device node.
This fixes the docker in docker use case while still making sure
the container is not allowed read/write access to the rootfs.
Note, this could also be fixed by simply skipping {"Type : "b"}
while creating the device cgroup with libcontainer.
But this seems to be undocumented behaviour at this point,
hence refrained from taking this approach.

Fixes #806

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>