### PR TITLE
actions: Add action to perform checks for pull requests

### DIFF
--- a/.github/workflows/PR-wip-checks.yaml
+++ b/.github/workflows/PR-wip-checks.yaml
@@ -1,0 +1,21 @@
+name: Pull request WIP checks
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  pr_wip_check:
+    runs-on: ubuntu-latest
+    name: WIP Check
+    steps:
+    - name: WIP Check
+      uses: tim-actions/wip-check@1c2a1ca6c110026b3e2297bb2ef39e1747b5a755
+      with:
+        labels: '["do-not-merge", "wip", "rfc"]'
+        keywords: '["WIP", "wip", "RFC", "rfc", "dnm", "DNM", "do-not-merge"]'

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -1,0 +1,22 @@
+name: DCO check
+on: 
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  dco_check_job:
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@ed97a21c3f83c3417e67a4733ea76887293a2c8f
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
Use github actions for performing wip and DCO checks on PRs.
Note since external actions for DCO check access github token, a
particular sha for the actions is used.

Fixes: github.com/kata-containers/kata-containers#437

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit 96d8dd3ff9f5df609c5d46cc833e01b264dd292b)