### PR TITLE
kata-agent: increase netlink socket receive buffer size to 4MB.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,12 +71,11 @@
   version = "v1.13.1"
 
 [[projects]]
-  digest = "1:9d8fe33c2e1aa01c76db67f285ffdb7dbdb5c5d90d9deb296526d67b9798ce7b"
+  digest = "1:97176fe8a268479a527d08df458c269dc27abf59c1643807d4e36398cbd9ef2d"
   name = "github.com/docker/go-units"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
-  version = "v0.3.2"
+  revision = "519db1ee28dcc9fd2474ae59fca29a810482bfb1"
 
 [[projects]]
   digest = "1:ca3369c0fc8d471d8698f85a37a4f8c98a847402681a31431fb87a84fa2e5373"
@@ -402,6 +401,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/docker/docker/pkg/parsers",
+    "github.com/docker/go-units",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,6 +50,9 @@
   name = "github.com/uber/jaeger-client-go"
   version = "2.15.0"
 
+[[constraint]]
+  name = "github.com/docker/go-units"
+  revision = "519db1ee28dcc9fd2474ae59fca29a810482bfb1"
 
 [prune]
   non-go = true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ The pipe's capacity for stdout/stderr can be modified by specifying the `agent.c
 to the guest kernel command line. For example, `agent.container_pipe_size=2097152` will set the stdout and stderr
 pipes to 2097152 bytes.
 
+## Uevent Netlink Socket Receive Buffer Size
+
+When hotplugging a huge size memory into the Kata VM, the kernel in the VM will produce a lot of memory object add
+uevents and send all these uevents to Kata agent by netlink socket. However, default netlink socket receive buffer
+size is 4KB, which is too small and can only hold 256 memory add uevents. If memory add uevents number is larger
+than 256, the left uevents can not be received and processed by Kata agent.
+
+The uevent netlink socket receive buffer size can be modified by specifying the `agent.netlink_recv_buf_size` flag
+to the guest kernel command line. For example, `agent.netlink_recv_buf_size=2MB` will set the uevent netlink socket
+receive buffer size to 2MB value. `agent.netlink_recv_buf_size` valid value range is `[4KB ~ 4MB]` and value can be
+set in human-readable memory format or pure digital number format(default memory unit is byte). 
+
+
 [1]: https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md
 [2]: https://golang.org/pkg/time/#ParseDuration
 [3]: http://man7.org/linux/man-pages/man7/pipe.7.html

--- a/agent.go
+++ b/agent.go
@@ -192,6 +192,14 @@ var unifiedCgroupHierarchy = false
 // Size in bytes of the stdout/stderr pipes created for each container.
 var containerPipeSize = uint32(0)
 
+const (
+	minNetlinkSockRecvBufSize = 4 * 1024
+	maxNetlinkSockRecvBufSize = 4 * 1024 * 1024
+)
+
+// Size in bytes of the netlink socket recv buf size
+var netlinkSockRecvBufSize = uint32(0)
+
 // commType is used to denote the communication channel type used.
 type commType int
 
@@ -710,7 +718,7 @@ func (s *sandbox) waitForStopServer() {
 func (s *sandbox) listenToUdevEvents() {
 	fieldLogger := agentLog.WithField("subsystem", "udevlistener")
 
-	uEvHandler, err := uevent.NewHandler()
+	uEvHandler, err := uevent.NewHandler(netlinkSockRecvBufSize)
 	if err != nil {
 		fieldLogger.Warnf("Error starting uevent listening loop %s", err)
 		return

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -18,7 +18,7 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {
 		return "About a minute"
-	} else if minutes < 46 {
+	} else if minutes < 60 {
 		return fmt.Sprintf("%d minutes", minutes)
 	} else if hours := int(d.Hours() + 0.5); hours == 1 {
 		return "About an hour"

--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -31,7 +31,7 @@ type unitMap map[string]int64
 var (
 	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
 	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[iI]?[bB]?$`)
 )
 
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}

--- a/vendor/github.com/docker/go-units/ulimit.go
+++ b/vendor/github.com/docker/go-units/ulimit.go
@@ -96,8 +96,13 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	if soft > *hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+	if *hard != -1 {
+		if soft == -1 {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: soft: -1 (unlimited), hard: %d", *hard)
+		}
+		if soft > *hard {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+		}
 	}
 
 	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil


### PR DESCRIPTION
kata-agent: increase netlink socket receive buffer size to 4MB.

fixes: #813

reason: If hotplug huge size memory(for example 128GB) into guest,
kernel will produce a lot of memory add uevents and send to netlink socket,
however netlink socket default receive buffer size is 4KB, which is too small
to receive all memory add uevents.
So we need to increase the netlink socket receive buffer size to 4MB which is
large enough.

Signed-off-by: jiangpengfei9 <jiangpengfei9@huawei.com>