### PR TITLE
network: Fix Could not create destination mount point: /etc/resolv.conf

### DIFF
--- a/network.go
+++ b/network.go
@@ -693,6 +693,11 @@ func setupDNS(dns []string) (err error) {
 		return nil
 	}
 
+	if _, err := os.Stat(guestDNSFile); err != nil && os.IsNotExist(err) {
+		agentLog.Errorf("%s is not exist in guest, dns service may be unavailable", guestDNSFile)
+		return nil
+	}
+
 	if err := os.MkdirAll(filepath.Dir(kataGuestSandboxDNSFile), 0700); err != nil {
 		return err
 	}


### PR DESCRIPTION
agent does not check if /etc/resolv.conf exists, if it does not exist,
setDns will fail and causes the container to fail to run. sometimes,we
don't need dns in guest vm, so it's better to skip and return nil if
/etc/resolv.conf does not exists.

Fixes: #829

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>