### PR TITLE
libcontainer: kill all processes in container' cgroup

### DIFF
--- a/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
@@ -38,7 +38,8 @@ type containerState interface {
 }
 
 func destroy(c *linuxContainer) error {
-	if !c.config.Namespaces.Contains(configs.NEWPID) {
+	if !c.config.Namespaces.Contains(configs.NEWPID) ||
+		c.config.Namespaces.PathOf(configs.NEWPID) != "" {
 		if err := signalAllProcesses(c.cgroupManager, unix.SIGKILL); err != nil {
 			logrus.Warn(err)
 		}


### PR DESCRIPTION
reproduce:
cid=$(crictl runp examples/untrusted-podsandbox-config.json)
crictl create  $cid examples/container-config.yaml examples/untrusted-podsandbox-config.json
crictl start $cid
crictl exec -ti  $cid sh

**Don't exit sh and in another console, run crictl stop.**
crictl stop $cid

Fixes: #837.

the root cause is that container exit , but it don't kill the processes in its cgroup, so the cgroup path is busy, and the cgroup path
cannot be deleted.

runc has fix the issue, details for opencontainers/runc#2085

**go dep and go modules are not compatible**

To import v2 or a version after v2 of a dependency package, go module need to add /v2(or a higher version) to the path of import path. take runc for example,
```
require (
        github.com/checkpoint-restore/go-criu/v4 v4.1.0
		...
```
this means runc need github.com/checkpoint-restore/go-criu, and the version of go-criu is v4.1.0, runc import go-criu like this,
```
criu "github.com/checkpoint-restore/go-criu/v4/rpc"
```
if use dep to update vendor fo agent, agent need runc，and runc need go-criu, so dep will try to get github.com/checkpoint-restore/go-criu/v4 
but it is not exist. dep will fail. So we can't use dep to update vendor anymore.

so I change runc code directly in the vendor dir.
Signed-off-by: Shukui Yang <keloyangsk@gmail.com>