### PR TITLE
Allow VFIO devices to be passed through as VFIO devices

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -756,8 +756,7 @@ func (s *sandbox) listenToUdevEvents() {
 		fieldLogger.Infof("Received add uevent")
 
 		// Check if device hotplug event results in a device node being created.
-		if uEv.DevName != "" &&
-			(strings.HasPrefix(uEv.DevPath, rootBusPath) || strings.HasPrefix(uEv.DevPath, acpiDevPath)) {
+		if strings.HasPrefix(uEv.DevPath, rootBusPath) || strings.HasPrefix(uEv.DevPath, acpiDevPath) {
 			// Lock is needed to safely read and modify the sysToDevMap and deviceWatchers.
 			// This makes sure that watchers do not access the map while it is being updated.
 			s.Lock()

--- a/agent.go
+++ b/agent.go
@@ -47,6 +47,8 @@ const (
 	bashPath         = "/bin/bash"
 	shPath           = "/bin/sh"
 	debugConsolePath = "/dev/console"
+
+	vfioGroupPath = "/devices/virtual/vfio"
 )
 
 var (
@@ -756,7 +758,9 @@ func (s *sandbox) listenToUdevEvents() {
 		fieldLogger.Infof("Received add uevent")
 
 		// Check if device hotplug event results in a device node being created.
-		if strings.HasPrefix(uEv.DevPath, rootBusPath) || strings.HasPrefix(uEv.DevPath, acpiDevPath) {
+		if strings.HasPrefix(uEv.DevPath, rootBusPath) ||
+			strings.HasPrefix(uEv.DevPath, acpiDevPath) ||
+			strings.HasPrefix(uEv.DevPath, vfioGroupPath) {
 			// Lock is needed to safely read and modify the sysToDevMap and deviceWatchers.
 			// This makes sure that watchers do not access the map while it is being updated.
 			s.Lock()

--- a/agent.go
+++ b/agent.go
@@ -181,7 +181,7 @@ var logsVSockPort = uint32(0)
 var debugConsoleVSockPort = uint32(0)
 
 // Timeout waiting for a device to be hotplugged
-var hotplugTimeout = 3 * time.Second
+var hotplugTimeout = 10 * time.Second
 
 // Specify the log level
 var logLevel = defaultLogLevel

--- a/agent_test.go
+++ b/agent_test.go
@@ -30,7 +30,6 @@ const (
 	testExecID      = "testExecID"
 	testContainerID = "testContainerID"
 	testFileMode    = os.FileMode(0640)
-	testDirMode     = os.FileMode(0750)
 )
 
 func createFileWithPerms(file, contents string, perms os.FileMode) error {

--- a/device.go
+++ b/device.go
@@ -34,7 +34,12 @@ const (
 	driverNvdimmType    = "nvdimm"
 	driverEphemeralType = "ephemeral"
 	driverLocalType     = "local"
-	vmRootfs            = "/"
+
+	//VFIO devices to be bound to the VM's native drivers (this is
+	//Kata specific behaviour, that requires careful configuration
+	//to get something usable inside the container)
+	driverVfioVmType = "vfio-vm"
+	vmRootfs         = "/"
 )
 
 const (
@@ -97,6 +102,7 @@ var deviceHandlerList = map[string]deviceHandler{
 	driverBlkCCWType:  virtioBlkCCWDeviceHandler,
 	driverSCSIType:    virtioSCSIDeviceHandler,
 	driverNvdimmType:  nvdimmDeviceHandler,
+	driverVfioVmType:  vfioDeviceHandler,
 }
 
 func rescanPciBus() error {
@@ -257,6 +263,46 @@ func virtioSCSIDeviceHandler(ctx context.Context, device pb.Device, spec *pb.Spe
 
 func nvdimmDeviceHandler(_ context.Context, device pb.Device, spec *pb.Spec, s *sandbox, devIdx devIndex) error {
 	return updateSpecDeviceList(device, spec, devIdx)
+}
+
+// device.Options should have one entry for each PCI device in the VFIO group
+// Each option should have the form "DDDD:BB:DD.F=NN/MM"
+//     DDDD:BB:DD.F is the device's PCI address in the host
+//     NN is the PCI slot of the device's bridge, MM is the PCI slot of the device
+func vfioDeviceHandler(ctx context.Context, device pb.Device, spec *pb.Spec, s *sandbox, devIdx devIndex) error {
+	fieldLogger := agentLog.WithField("host-dev", device.ContainerPath)
+
+	for _, opt := range device.Options {
+		tokens := strings.Split(opt, "=")
+		if len(tokens) != 2 {
+			return fmt.Errorf("Malformed VFIO option %q", opt)
+		}
+
+		hostBdf := tokens[0]
+		guestPCIPath := PciPath{tokens[1]}
+
+		sysfsRelPath, err := pciPathToSysfs(guestPCIPath)
+		if err != nil {
+			return err
+		}
+
+		// We don't actually care what the /dev node is called
+		// (and there may not be any), but this will wait for
+		// a uevent that indicates the device is ready
+		_, err = getDeviceName(s, sysfsRelPath)
+		if err != nil {
+			return err
+		}
+
+		tokens = strings.Split(sysfsRelPath, "/")
+		guestBdf := tokens[len(tokens)-1]
+
+		fieldLogger.WithField("host-bdf", hostBdf).WithField("guest-bdf", guestBdf).Debug("VFIO: PCI device ready")
+	}
+
+	fieldLogger.Debug("VFIO: Group complete")
+
+	return nil
 }
 
 // updateSpecDeviceList takes a device description provided by the caller,

--- a/device.go
+++ b/device.go
@@ -142,6 +142,7 @@ func pciPathToSysfsImpl(pciPath PciPath) (string, error) {
 }
 
 func getDeviceName(s *sandbox, devID string) (string, error) {
+	var found bool
 	var devName string
 	var notifyChan chan string
 
@@ -151,7 +152,7 @@ func getDeviceName(s *sandbox, devID string) (string, error) {
 	s.Lock()
 	for key, value := range s.sysToDevMap {
 		if strings.Contains(key, devID) {
-			devName = value
+			devName, found = value, true
 			fieldLogger.Infof("Device: %s found in device map", devID)
 			break
 		}
@@ -162,13 +163,13 @@ func getDeviceName(s *sandbox, devID string) (string, error) {
 	// The key of the watchers map is the device we are interested in.
 	// Note this is done inside the lock, not to miss any events from the
 	// global udev listener.
-	if devName == "" {
+	if !found {
 		notifyChan = make(chan string, 1)
 		s.deviceWatchers[devID] = notifyChan
 	}
 	s.Unlock()
 
-	if devName == "" {
+	if !found {
 		fieldLogger.Infof("Waiting on channel for device: %s notification", devID)
 		select {
 		case devName = <-notifyChan:

--- a/device.go
+++ b/device.go
@@ -373,7 +373,17 @@ func vfioDeviceHandler(ctx context.Context, device pb.Device, spec *pb.Spec, s *
 		fieldLogger.WithField("host-bdf", hostBdf).WithField("guest-bdf", guestBdf).Debug("VFIO: Device complete")
 	}
 
-	fieldLogger.WithField("guest-group", group).Debug("VFIO: Group complete")
+	fieldLogger.WithField("guest-dev", device.VmPath).Debug("VFIO: Group complete")
+
+	if rebindToVfio {
+		vmpath, err := getDeviceName(s, filepath.Join("vfio", group))
+		if err != nil {
+			return fmt.Errorf("Couldn't find device for guest VFIO group %s: %s",
+				group, err)
+		}
+		device.VmPath = vmpath
+		return updateSpecDevice(spec, devIdx, device.ContainerPath, device.VmPath, device.VmPath)
+	}
 
 	return nil
 }

--- a/device.go
+++ b/device.go
@@ -42,12 +42,7 @@ const (
 	vmRootfs         = "/"
 )
 
-const (
-	pciBusMode = 0220
-)
-
 var (
-	pciBusRescanFile = sysfsDir + "/bus/pci/rescan"
 	systemDevPath    = "/dev"
 	getSCSIDevPath   = getSCSIDevPathImpl
 	getPmemDevPath   = getPmemDevPathImpl
@@ -103,10 +98,6 @@ var deviceHandlerList = map[string]deviceHandler{
 	driverSCSIType:    virtioSCSIDeviceHandler,
 	driverNvdimmType:  nvdimmDeviceHandler,
 	driverVfioVmType:  vfioDeviceHandler,
-}
-
-func rescanPciBus() error {
-	return ioutil.WriteFile(pciBusRescanFile, []byte{'1'}, pciBusMode)
 }
 
 // pciPathToSysfs fetches the sysfs path for a PCI path, relative to
@@ -196,14 +187,6 @@ func getDeviceName(s *sandbox, devID string) (string, error) {
 func getPCIDeviceNameImpl(s *sandbox, pciPath PciPath) (string, error) {
 	sysfsRelPath, err := pciPathToSysfs(pciPath)
 	if err != nil {
-		return "", err
-	}
-
-	fieldLogger := agentLog.WithField("sysfsRelPath", sysfsRelPath)
-
-	// Rescan pci bus if we need to wait for a new pci device
-	if err = rescanPciBus(); err != nil {
-		fieldLogger.WithError(err).Error("Failed to scan pci bus")
 		return "", err
 	}
 

--- a/device_test.go
+++ b/device_test.go
@@ -482,19 +482,19 @@ func TestUpdateSpecDeviceList(t *testing.T) {
 	var containerPath, vmPath string
 
 	// containerPath empty
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.Error(err)
 
 	containerPath = "/dev/null"
 
 	// Linux is nil
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.Error(err)
 
 	spec.Linux = &pb.Linux{}
 
 	/// Linux.Devices empty
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.Error(err)
 
 	spec.Linux.Devices = []pb.LinuxDevice{
@@ -507,20 +507,20 @@ func TestUpdateSpecDeviceList(t *testing.T) {
 	devIdx = makeDevIndex(spec)
 
 	// mmPath empty
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.Error(err)
 
 	vmPath = "/dev/null"
 
 	// guest and host path are not the same
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.Error(err)
 
 	spec.Linux.Devices[0].Path = containerPath
 	devIdx = makeDevIndex(spec)
 
 	// spec.Linux.Resources is nil
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.NoError(err)
 
 	// update both devices and cgroup lists
@@ -541,7 +541,7 @@ func TestUpdateSpecDeviceList(t *testing.T) {
 	}
 	devIdx = makeDevIndex(spec)
 
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.NoError(err)
 }
 
@@ -619,7 +619,7 @@ func TestUpdateSpecDeviceListGuestHostConflict(t *testing.T) {
 	assert.Equal(hostMajorB, spec.Linux.Resources.Devices[1].Major)
 	assert.Equal(hostMinorB, spec.Linux.Resources.Devices[1].Minor)
 
-	err = updateSpecDevice(spec, devIdx, containerPathA, vmPathA)
+	err = updateSpecDevice(spec, devIdx, containerPathA, vmPathA, containerPathA)
 	assert.NoError(err)
 
 	assert.Equal(guestMajorA, spec.Linux.Devices[0].Major)
@@ -632,7 +632,7 @@ func TestUpdateSpecDeviceListGuestHostConflict(t *testing.T) {
 	assert.Equal(hostMajorB, spec.Linux.Resources.Devices[1].Major)
 	assert.Equal(hostMinorB, spec.Linux.Resources.Devices[1].Minor)
 
-	err = updateSpecDevice(spec, devIdx, containerPathB, vmPathB)
+	err = updateSpecDevice(spec, devIdx, containerPathB, vmPathB, containerPathB)
 	assert.NoError(err)
 
 	assert.Equal(guestMajorA, spec.Linux.Devices[0].Major)
@@ -704,7 +704,7 @@ func TestUpdateSpecDeviceListCharBlockConflict(t *testing.T) {
 	assert.Equal(hostMinor, spec.Linux.Resources.Devices[1].Minor)
 
 	devIdx := makeDevIndex(spec)
-	err = updateSpecDevice(spec, devIdx, containerPath, vmPath)
+	err = updateSpecDevice(spec, devIdx, containerPath, vmPath, containerPath)
 	assert.NoError(err)
 
 	// Only the char device, not the block device should be updated

--- a/device_test.go
+++ b/device_test.go
@@ -719,45 +719,6 @@ func TestUpdateSpecDeviceListCharBlockConflict(t *testing.T) {
 	assert.Equal(hostMinor, spec.Linux.Resources.Devices[1].Minor)
 }
 
-func TestRescanPciBus(t *testing.T) {
-	skipUnlessRoot(t)
-
-	assert := assert.New(t)
-
-	err := rescanPciBus()
-	assert.Nil(err)
-
-}
-
-func TestRescanPciBusSubverted(t *testing.T) {
-	assert := assert.New(t)
-
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
-
-	rescanDir := filepath.Join(dir, "rescan-dir")
-
-	err = os.MkdirAll(rescanDir, testDirMode)
-	assert.NoError(err)
-
-	rescan := filepath.Join(rescanDir, "rescan")
-
-	savedFile := pciBusRescanFile
-	defer func() {
-		pciBusRescanFile = savedFile
-	}()
-
-	pciBusRescanFile = rescan
-
-	err = rescanPciBus()
-	assert.NoError(err)
-
-	os.RemoveAll(rescanDir)
-	err = rescanPciBus()
-	assert.Error(err)
-}
-
 func TestVirtioMmioBlkDeviceHandler(t *testing.T) {
 	assert := assert.New(t)
 
@@ -891,13 +852,6 @@ func TestGetPCIDeviceName(t *testing.T) {
 	sb := sandbox{
 		deviceWatchers: make(map[string](chan string)),
 	}
-
-	_, err = getPCIDeviceNameImpl(&sb, PciPath{""})
-	assert.Error(err)
-
-	rescanDir := filepath.Dir(pciBusRescanFile)
-	err = os.MkdirAll(rescanDir, testDirMode)
-	assert.NoError(err)
 
 	_, err = getPCIDeviceNameImpl(&sb, PciPath{""})
 	assert.Error(err)

--- a/device_test.go
+++ b/device_test.go
@@ -953,6 +953,13 @@ func TestGetDeviceName(t *testing.T) {
 	oneGetDeviceNameTest(t, sysName, devName, busID)
 }
 
+func TestGetDeviceNameEmptyDev(t *testing.T) {
+	busID := "0000:01:00.0"
+	sysName := path.Join("/devices/pci0000:00/0000:00:1c.0", busID)
+
+	oneGetDeviceNameTest(t, sysName, "", busID)
+}
+
 func TestUpdateDeviceCgroupForGuestRootfs(t *testing.T) {
 	skipUnlessRoot(t)
 	assert := assert.New(t)

--- a/grpc.go
+++ b/grpc.go
@@ -618,12 +618,6 @@ func (a *agentGRPC) CreateContainer(ctx context.Context, req *pb.CreateContainer
 		return emptyResp, err
 	}
 
-	// re-scan PCI bus
-	// looking for hidden devices
-	if err = rescanPciBus(); err != nil {
-		agentLog.WithError(err).Warn("Could not rescan PCI bus")
-	}
-
 	// Some devices need some extra processing (the ones invoked with
 	// --device for instance), and that's what this call is doing. It
 	// updates the devices listed in the OCI spec, so that they actually

--- a/mount_test.go
+++ b/mount_test.go
@@ -605,7 +605,8 @@ func TestStorageHandlers(t *testing.T) {
 		}
 
 		sb := sandbox{
-			storages: make(map[string]*sandboxStorage),
+			storages:       make(map[string]*sandboxStorage),
+			deviceWatchers: make(map[string](chan string)),
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This patches series implements a fix for https://github.com/kata-containers/agent/issues/833.

It's based on pull requests for other issues, specifically https://github.com/kata-containers/agent/pull/782 and https://github.com/kata-containers/agent/pull/836, so those should be merged first.

This series on its own won't do anything without corresponding host-side fixes for https://github.com/kata-containers/runtime/issues/2938 which I'm still polishing for a PR.
