### PR TITLE
Consistent device address matching between `getDeviceName()` and `listenToUdevEvents()`

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -774,34 +774,14 @@ func (s *sandbox) listenToUdevEvents() {
 
 				fieldLogger.Infof("Got a wait channel for device %s", devAddress)
 
-				// blk driver case
-				if strings.HasPrefix(uEv.DevPath, filepath.Join(rootBusPath, devAddress)) {
-					goto OUT
-				}
-
-				// pmem/nvdimm case
-				if strings.Contains(uEv.DevPath, pfnDevPrefix) && strings.HasSuffix(uEv.DevPath, devAddress) {
-					goto OUT
-				}
-
+				// This is a pretty imperfect way of
+				// matching, but it's the same as we
+				// use in getDeviceName()
 				if strings.Contains(uEv.DevPath, devAddress) {
-					// scsi driver case
-					if strings.HasSuffix(devAddress, scsiBlockSuffix) {
-						goto OUT
-					}
-					// blk-ccw driver case
-					if strings.HasSuffix(devAddress, blkCCWSuffix) {
-						goto OUT
-					}
+					ch <- uEv.DevName
+					close(ch)
+					delete(s.deviceWatchers, devAddress)
 				}
-
-				continue
-
-			OUT:
-				ch <- uEv.DevName
-				close(ch)
-				delete(s.deviceWatchers, devAddress)
-
 			}
 
 			s.Unlock()

--- a/device.go
+++ b/device.go
@@ -144,10 +144,10 @@ func getDeviceName(s *sandbox, devID string) (string, error) {
 
 	// Check if the dev identifier is in PCI device map.
 	s.Lock()
-	for key, value := range s.pciDeviceMap {
+	for key, value := range s.sysToDevMap {
 		if strings.Contains(key, devID) {
 			devName = value
-			fieldLogger.Infof("Device: %s found in pci device map", devID)
+			fieldLogger.Infof("Device: %s found in device map", devID)
 			break
 		}
 	}

--- a/device_amd64.go
+++ b/device_amd64.go
@@ -16,8 +16,4 @@ const (
 	// processors, thermal zones. Those objects are exported to user space via
 	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
 	acpiDevPath = "/devices/LNXSYSTM"
-
-	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
-	// in a subdirectory whose prefix is pfn (page frame number).
-	pfnDevPrefix = "/pfn"
 )

--- a/device_arm64.go
+++ b/device_arm64.go
@@ -15,8 +15,4 @@ const (
 	// processors, thermal zones. Those objects are exported to user space via
 	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
 	acpiDevPath = "/devices/LNXSYSTM"
-
-	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
-	// in a subdirectory whose prefix is pfn (page frame number).
-	pfnDevPrefix = "/pfn"
 )

--- a/device_ppc64le.go
+++ b/device_ppc64le.go
@@ -16,8 +16,4 @@ const (
 	// processors, thermal zones. Those objects are exported to user space via
 	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
 	acpiDevPath = "/devices/LNXSYSTM"
-
-	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
-	// in a subdirectory whose prefix is pfn (page frame number).
-	pfnDevPrefix = "/pfn"
 )

--- a/device_s390x.go
+++ b/device_s390x.go
@@ -16,8 +16,4 @@ const (
 	// processors, thermal zones. Those objects are exported to user space via
 	// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
 	acpiDevPath = "/devices/LNXSYSTM"
-
-	// /dev/pmemX devices exported in the ACPI sysfs (/devices/LNXSYSTM) are
-	// in a subdirectory whose prefix is pfn (page frame number).
-	pfnDevPrefix = "/pfn"
 )

--- a/device_test.go
+++ b/device_test.go
@@ -872,12 +872,12 @@ func TestGetDeviceName(t *testing.T) {
 	busID := "0.0.0005"
 	devPath := path.Join("/devices/css0/0.0.0004", busID, "virtio4/block", devName)
 
-	pcidevicemap := make(map[string]string)
-	pcidevicemap[devPath] = devName
+	systodevmap := make(map[string]string)
+	systodevmap[devPath] = devName
 
 	sb := sandbox{
 		deviceWatchers: make(map[string](chan string)),
-		pciDeviceMap:   pcidevicemap,
+		sysToDevMap:    systodevmap,
 	}
 
 	name, err := getDeviceName(&sb, busID)
@@ -885,7 +885,7 @@ func TestGetDeviceName(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(name, path.Join(devRootPath, devName))
 
-	delete(sb.pciDeviceMap, devPath)
+	delete(sb.sysToDevMap, devPath)
 
 	go func() {
 		for {

--- a/mount_test.go
+++ b/mount_test.go
@@ -248,11 +248,11 @@ func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
 	defer syscall.Unmount(storage.MountPoint, 0)
 
 	s := &sandbox{
-		pciDeviceMap: make(map[string]string),
+		sysToDevMap: make(map[string]string),
 	}
 
 	s.Lock()
-	s.pciDeviceMap[completePCIAddr] = devPath
+	s.sysToDevMap[completePCIAddr] = devPath
 	s.Unlock()
 
 	storage.Fstype = "bind"
@@ -268,7 +268,7 @@ func TestVirtioBlkStorageHandlerSuccessful(t *testing.T) {
 func TestNvdimmStorageHandlerSuccessful(t *testing.T) {
 	skipUnlessRoot(t)
 
-	completePCIAddr := "/devices/LNXSYSTM/LNXSYBUS/ACPI/ndbus0/region1/pfn1.1/block/pmem0"
+	sysfsPath := "/devices/LNXSYSTM/LNXSYBUS/ACPI/ndbus0/region1/pfn1.1/block/pmem0"
 	pmemDev := "/dev/pmem0"
 	devPath, err := createFakeDevicePath()
 	if err != nil {
@@ -289,11 +289,11 @@ func TestNvdimmStorageHandlerSuccessful(t *testing.T) {
 	defer syscall.Unmount(storage.MountPoint, 0)
 
 	s := &sandbox{
-		pciDeviceMap: make(map[string]string),
+		sysToDevMap: make(map[string]string),
 	}
 
 	s.Lock()
-	s.pciDeviceMap[completePCIAddr] = devPath
+	s.sysToDevMap[sysfsPath] = devPath
 	s.Unlock()
 
 	storage.Fstype = "bind"


### PR DESCRIPTION
This is a fix for issue #848.  While we're there, simplify the code a bit and rename a poorly named data structure.
