### PR TITLE
DNM: Revert "device: Ease device access for rootfs device to allow node cr…

### DIFF
--- a/device.go
+++ b/device.go
@@ -523,7 +523,7 @@ func updateDeviceCgroupForGuestRootfs(spec *pb.Spec) {
 		Major:  devMajor,
 		Minor:  devMinor,
 		Type:   "b",
-		Access: "rw",
+		Access: "rwm",
 	}
 
 	spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, nvdimmCg)


### PR DESCRIPTION
…eation"

This reverts commit 5dc7ae4bebe5413e957bb52387a13fcaa0c6a6e5.