### PR TITLE
mount : Fix mount with "rw" option

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -51,6 +51,7 @@ var flagList = map[string]int{
 	"relatime":    unix.MS_RELATIME,
 	"remount":     unix.MS_REMOUNT,
 	"ro":          unix.MS_RDONLY,
+	"rw":          0,
 	"silent":      unix.MS_SILENT,
 	"strictatime": unix.MS_STRICTATIME,
 	"sync":        unix.MS_SYNCHRONOUS,


### PR DESCRIPTION
I add a ceph rbd device to a kata containers, and expect kata-agent(mountStorage) can mount it.
but it failed, the err info is "invalid argument", I spend some time and find the option is wrong. 

we can reproduce like this,
```
1. make sure /dev/sdb(or other device) not mounted
2. mount /dev/sdb (./devmount /dev/sdb, you can find the code of devmount.go  at the end of this pr)
```
To simplify the problem, I have the test in my host OS.
```
[root@centos3 ~]# mount |grep sdb #make sure /dev/sdb not mounted
[root@centos3 ~]# ./devmount /dev/sdb 
mount /dev/sdb /mnt ext4 2097152 rw,stripe=1024
mount failed, invalid argument
```

If I add a change to devmount.go, devmount will mount successfully
```
[root@centos3 test]# git diff        
diff --git a/devmount.go b/devmount.go
index cc2e878..1c5c9fb 100644
--- a/devmount.go
+++ b/devmount.go
@@ -26,7 +26,7 @@ var flagList = map[string]int{
        "relatime":   unix.MS_RELATIME,
        "remount":    unix.MS_REMOUNT,
        "ro":         unix.MS_RDONLY,
-       //"rw":          0,
+       "rw":          0,
        "silent":      unix.MS_SILENT,
        "strictatime": unix.MS_STRICTATIME,
        "sync":        unix.MS_SYNCHRONOUS,

[root@centos3 test]# go build devmount.go
[root@centos3 test]# ./devmount /dev/sdb
mount /dev/sdb /mnt ext4 2097152 stripe=1024
mount successful
```
parseMountFlagsAndOptions can't handle options with "rw" correctly
```
storageOptions := []string{"rw","relatime", "stripe=1024"}
flags, options := parseMountFlagsAndOptions(storageOptions)
```
For the code above, the result of options is "rw,stripe=1024", and  syscall.Mount(dst , ..., options) 
will return "invalid argument" error. If mount without rw/ro option, the mount access will be "rw" by default,
so options can be "stripe=1024",should be not "rw,stripe=1024".

the code of devmount.go
```
package main

import (
        "fmt"
        "os"
        "strings"
        "syscall"

        "golang.org/x/sys/unix"
)

var flagList = map[string]int{
        "acl":         unix.MS_POSIXACL,
        "bind":        unix.MS_BIND,
        "defaults":    0,
        "dirsync":     unix.MS_DIRSYNC,
        "iversion":    unix.MS_I_VERSION,
        "lazytime":    unix.MS_LAZYTIME,
        "mand":        unix.MS_MANDLOCK,
        "noatime":     unix.MS_NOATIME,
        "nodev":       unix.MS_NODEV,
        "nodiratime":  unix.MS_NODIRATIME,
        "noexec":      unix.MS_NOEXEC,
        "nosuid":      unix.MS_NOSUID,
        "rbind":       unix.MS_BIND | unix.MS_REC,
        "relatime":    unix.MS_RELATIME,
        "remount":     unix.MS_REMOUNT,
        "ro":          unix.MS_RDONLY,
        "rw":          0,
        "silent":      unix.MS_SILENT,
        "strictatime": unix.MS_STRICTATIME,
        "sync":        unix.MS_SYNCHRONOUS,
        "private":     unix.MS_PRIVATE,
        "shared":      unix.MS_SHARED,
        "slave":       unix.MS_SLAVE,
        "unbindable":  unix.MS_UNBINDABLE,
        "rprivate":    unix.MS_PRIVATE | unix.MS_REC,
        "rshared":     unix.MS_SHARED | unix.MS_REC,
        "rslave":      unix.MS_SLAVE | unix.MS_REC,
        "runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
}

func parseMountFlagsAndOptions(optionList []string) (int, string) {
        var (
                flags   int
                options []string
        )

        for _, opt := range optionList {
                flag, ok := flagList[opt]
                if ok {
                        flags |= flag
                        continue
                }

                options = append(options, opt)
        }

        return flags, strings.Join(options, ",")
}

func main() {
        dev := os.Args[1]
        storageOptions := []string{"rw", "relatime", "stripe=1024"}

        dst := "/mnt"
        fsType := "ext4"

        flags, options := parseMountFlagsAndOptions(storageOptions)
        fmt.Printf("mount %s %s %s %d %s\n", dev, dst, fsType, uintptr(flags), options)

        err := syscall.Mount(dev, dst, fsType, uintptr(flags), options)
        if err != nil {
                fmt.Printf("mount failed, %v\n", err)
                return
        }
        fmt.Printf("mount successful\n")
}
```
Signed-off-by: Shukui Yang <keloyangsk@gmail.com>