### PR TITLE
agent: Fix resourece leak

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"syscall"
 	"testing"
@@ -988,4 +989,24 @@ func TestRunOOMEventMonitor(t *testing.T) {
 	assert.Equal(cid, oomEvent)
 
 	close(eventChan)
+}
+
+func TestExitProcess(t *testing.T) {
+	assert := assert.New(t)
+	containerExitProcess := exitProcess{}
+	for i := 0; i <= maxExitCodeNum; i++ {
+		id := fmt.Sprintf("id-%d", i)
+		containerExitProcess.add(id, nil)
+	}
+
+	listLen := len(containerExitProcess.exitCodes)
+	statusList := make(exitStatusList, listLen)
+	index := 0
+	for _, status := range containerExitProcess.exitCodes {
+		statusList[index] = status
+		index++
+	}
+	sort.Sort(statusList)
+	assert.Equal(statusList[0].sequenceNum, maxExitCodeNum/2)
+	assert.Equal(statusList[listLen-1].sequenceNum, maxExitCodeNum)
 }

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -738,6 +738,9 @@ func TestSingleWaitProcess(t *testing.T) {
 		exitCodeCh: make(chan int, 1),
 	}
 
+	a.addExitCodeProcess(a.sandbox.containers[containerID].processes[containerID],
+		a.sandbox.containers[containerID])
+
 	go func() {
 		time.Sleep(time.Second)
 		a.sandbox.containers[containerID].processes[containerID].exitCodeCh <- exitCode
@@ -776,6 +779,9 @@ func TestMultiWaitProcess(t *testing.T) {
 		process:    libcontainer.Process{},
 		exitCodeCh: make(chan int, 1),
 	}
+
+	a.addExitCodeProcess(a.sandbox.containers[containerID].processes[containerID],
+		a.sandbox.containers[containerID])
 
 	for i := 0; i < 10; i++ {
 		wg.Add(1)


### PR DESCRIPTION
Every ExecProcess will create a struct for process and container, and kata-agent need call WaitProcess to remove them.
Normally WaitProcess will be called by kata-shim(**exitcode, err := shim.wait()**)，but kata-shim can't do that in some cases, 
it will make resource leak, e.g. mem and /dev/pts/N. So I think the cleanup for ExecProcess can't depend on kata-shim calling WaitProcess,it should depends on whether the process exits.

take the following case, we will see the /det/pts/N leak,
1. create a pod with kata-container, omited.
2. terminal 1, check pts, and exec to kata-container
```
[root@centos0 deployment]# kubectl get pod
NAME                     READY     STATUS    RESTARTS   AGE
pts-6794f84bd9-jzp5b   1/1       Running   0          1h
# check pts 
[root@centos0 deployment]#  kubectl exec -ti pts-6794f84bd9-jzp5b ls /dev/pts
0  ptmx
# exec to kata container and run sleep 30, before sleep 30 exited, kill kata-shim(with  -terminal) at terminal 2
[root@centos0 deployment]#  kubectl exec -ti pts-6794f84bd9-jzp5b sleep 30
# check pts again
[root@centos0 deployment]#  kubectl exec -ti pts-6794f84bd9-jzp5b ls /dev/pts
0  1  ptmx
...
# repeat kubectl exec -ti pts-6794f84bd9-jzp5b sleep 30 and kill kata-shim
[root@centos0 deployment]#  kubectl exec -ti pts-6794f84bd9-jzp5b ls /dev/pts
0  1  2  3  4  5  6  7  9  8  ptmx
```
2. terminal 2, kill kata-shim which is created by **kubectl exec -ti pts-6794f84bd9-jzp5b sleep 30**
```
[root@centos1 ~]# ps -eaf|grep kata-shim
root      572188  572134  0 18:56 ?        00:00:00 /kata/bin/kata-shim -agent unix:///run/vc/sbs/56b5e8192430090ba129a7a4823d646a46bac5684055a3e557e8c87efaf37595/proxy.sock -container 56b5e8192430090ba129a7a4823d646a46bac5684055a3e557e8c87efaf37595 -exec-id 56b5e8192430090ba129a7a4823d646a46bac5684055a3e557e8c87efaf37595
root      572333  572314  0 18:56 ?        00:00:00 /kata/bin/kata-shim -agent unix:///run/vc/sbs/56b5e8192430090ba129a7a4823d646a46bac5684055a3e557e8c87efaf37595/proxy.sock -container 6e8a25168697148e7065a9253c2caa5626548f6ed02c877ddc9dc93caaa6b76f -exec-id 6e8a25168697148e7065a9253c2caa5626548f6ed02c877ddc9dc93caaa6b76f
root      823320  572314  0 20:32 pts/3    00:00:00 /kata/bin/kata-shim -agent unix:///run/vc/sbs/56b5e8192430090ba129a7a4823d646a46bac5684055a3e557e8c87efaf37595/proxy.sock -container 6e8a25168697148e7065a9253c2caa5626548f6ed02c877ddc9dc93caaa6b76f -exec-id 014f96c3-67a6-422c-9709-33f717cc624f -terminal
[root@centos1 ~]# kill -9 823320
```

