### PR TITLE
arm/pci: add create pci bus path support for acpi

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -711,7 +711,7 @@ func (s *sandbox) listenToUdevEvents() {
 	fieldLogger := agentLog.WithField("subsystem", "udevlistener")
 	rootBusPath, err := createRootBusPath()
 	if err != nil {
-		fieldLogger.Warnf("Error creating root bus path")
+		fieldLogger.WithError(err).Error("Fail to create root bus path")
 		return
 	}
 

--- a/device_arm64.go
+++ b/device_arm64.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -23,8 +24,15 @@ const (
 )
 
 func createRootBusPath() (string, error) {
+	acpiRootBusPath := "/devices/pci0000:00"
 	startRootBusPath := "/devices/platform"
 	endRootBusPath := "/pci0000:00"
+
+	acpiSysRootBusPath := filepath.Join(sysfsDir, acpiRootBusPath)
+	if _, err := os.Stat(acpiSysRootBusPath); err == nil {
+		return acpiRootBusPath, nil
+	}
+
 	sysStartRootBusPath := filepath.Join(sysfsDir, startRootBusPath)
 	files, err := ioutil.ReadDir(sysStartRootBusPath)
 	if err != nil {


### PR DESCRIPTION
PCI bus path in qemu/arm64 is different between acpi enabled and
disabled. It's better to check if there is a pci bus path for acpi which
is a static value before try to offer a varying pci bus path for no acpi.

Fixes: #881
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @devimc 