### PR TITLE
grpc: lock agent reaper to avoid wait race when run poststop oci hook

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -1268,6 +1268,10 @@ func (a *agentGRPC) RemoveContainer(ctx context.Context, req *pb.RemoveContainer
 	a.sandbox.Lock()
 	defer a.sandbox.Unlock()
 
+	// lock agent reaper to avoid wait race when run oci hook
+	a.sandbox.subreaper.lock()
+	defer a.sandbox.subreaper.unlock()
+
 	if timeout == 0 {
 		if err := ctr.removeContainer(); err != nil {
 			return emptyResp, err


### PR DESCRIPTION
Agent reaper routine will listen the ECHILD signal and wait the child process to reap.

At the same time, the oci hook running routine will also need to wait the child hook
process. So the race may occur with error like "wait: no child processes" in any side.

The reaper lock is necessary in container start and stop function where prestart,
poststart and poststop hook will be run.

Fixes: #886

Signed-off-by: Wang Xingxing <wangxingxing06@meituan.com>